### PR TITLE
JS tests and REAMDE improvements

### DIFF
--- a/wasm/README.md
+++ b/wasm/README.md
@@ -162,11 +162,10 @@ let [encryptedMsg, encryptMetadata] = await msg.pack_encrypted(
 let [encrypted_msg, encrypt_metadata] = await msg.pack_encrypted(
   BOB_DID,
   ALICE_DID,
-  null,
+  ALICE_DID, // Provide information about signer here
   did_resolver,
   secrets_resolver,
   {
-    sign_by: ALICE_DID, // Provide information about signer here
     forward: false, // Forward wrapping is unsupported in current version
   }
 );
@@ -215,8 +214,8 @@ Install `wasm-pack` from https://rustwasm.github.io/wasm-pack/installer/ and the
 
 ```bash
 wasm-pack build # Will output modules best-suited to be bundled with webpack
-wasm-pack build --targed=nodejs # Will output modules that can be directly consumed by NodeJS
-wasm-pack build --targed=web # Will output modules that can be directly consumed in browser without bundler usage
+wasm-pack build --target=nodejs # Will output modules that can be directly consumed by NodeJS
+wasm-pack build --target=web # Will output modules that can be directly consumed in browser without bundler usage
 ```
 
 ## How to test in NodeJS

--- a/wasm/tests-js/src/from_prior/pack.test.ts
+++ b/wasm/tests-js/src/from_prior/pack.test.ts
@@ -1,3 +1,4 @@
+import { FromPrior } from "didcomm-js";
 import {
   ALICE_DID_DOC,
   CHARLIE_DID_DOC,
@@ -29,12 +30,13 @@ test.each([
     case: "Explicit key",
   },
 ])(
-  "Message.pack-plaintext works for $case",
+  "FromPrior.pack works for $case",
   async ({ fromPrior, issuerKid, expKid }) => {
     const didResolver = new ExampleDIDResolver([
       ALICE_DID_DOC,
       CHARLIE_DID_DOC,
     ]);
+
     const secretsResolver = new ExampleSecretsResolver(CHARLIE_SECRETS);
 
     const [packed, kid] = await fromPrior.pack(
@@ -43,7 +45,10 @@ test.each([
       secretsResolver
     );
 
-    expect(typeof packed).toBe("string");
-    expect(kid).toEqual(expKid);
+    expect(typeof packed).toStrictEqual("string");
+    expect(kid).toStrictEqual(expKid);
+
+    const [unpacked, _] = await FromPrior.unpack(packed, didResolver);
+    expect(unpacked.as_value()).toStrictEqual(fromPrior.as_value());
   }
 );

--- a/wasm/tests-js/src/from_prior/unpack.test.ts
+++ b/wasm/tests-js/src/from_prior/unpack.test.ts
@@ -18,8 +18,10 @@ test("FromPrior.unpack works", async () => {
     didResolver
   );
 
+  // TODO: Use toStrictEq check after reduction of FromPrior fields
   expect(fromPrior.as_value()).toMatchObject(IFROM_PRIOR_FULL);
-  expect(issuerKid).toEqual(CHARLIE_SECRET_AUTH_KEY_ED25519.id);
+
+  expect(issuerKid).toStrictEqual(CHARLIE_SECRET_AUTH_KEY_ED25519.id);
 });
 
 test.each([
@@ -31,7 +33,7 @@ test.each([
   {
     jwt: FROM_PRIOR_JWT_INVALID_SIGNATURE,
     exp_err:
-      "Malformed: Unable to verify fromPrior signature: Unable decode signature: Invalid last symbol 66, offset 85.",
+      "Malformed: Unable to verify from_prior signature: Unable decode signature: Invalid last symbol 66, offset 85.",
     case: "Invalid signature",
   },
 ])("FromPrior.unpack handles $case", async ({ jwt, exp_err }) => {

--- a/wasm/tests-js/src/message/unpack.test.ts
+++ b/wasm/tests-js/src/message/unpack.test.ts
@@ -107,7 +107,7 @@ test.each([
       options
     );
 
-    expect(unpacked.as_value()).toMatchObject(expMsg);
-    expect(metadata).toEqual(expMetadata);
+    expect(unpacked.as_value()).toStrictEqual(expMsg);
+    expect(metadata).toStrictEqual(expMetadata);
   }
 );


### PR DESCRIPTION
* Corrected errors in README.md
* Better checks in `FromPrior.pack works` test
* Use toStrictEqual checks instead of toEq and toMatchObject when possible