### PR TITLE
Fix wrong type field name in Wasm binding

### DIFF
--- a/wasm/src/did/did_doc.rs
+++ b/wasm/src/did/did_doc.rs
@@ -108,6 +108,6 @@ const DIDCOMM_MESSAGING_SERVICE_TS: &'static str = r#"
 type DIDCommMessagingService = {
     service_endpoint: string,
     accept: Array<string>,
-    route_keys: Array<string>,
+    routing_keys: Array<string>,
 }
 "#;


### PR DESCRIPTION
- Fixed a wrong field name in DIDCommMessagingService type in Wasm binding.