### PR TITLE
Rollback version number to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = 'routing'
 
 [package]
 name = 'didcomm'
-version = '1.0.0'
+version = '0.4.0'
 authors = ['Vyacheslav Gudkov <vyacheslav.gudkov@dsr-corporation.com>']
 edition = '2018'
 description = 'DIDComm for Rust'

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To use `didcomm`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-didcomm = "0.3"
+didcomm = "0.4"
 ```
 
 ## Run examples

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'didcomm-uniffi'
-version = '1.0.0'
+version = '0.4.0'
 authors = ['Vyacheslav Gudkov <vyacheslav.gudkov@dsr-corporation.com>']
 edition = '2018'
 description = 'FFI wrapper for DIDComm'

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'didcomm-js'
-version = '1.0.0'
+version = '0.4.0'
 authors = ['Vyacheslav Gudkov <vyacheslav.gudkov@dsr-corporation.com>']
 edition = '2018'
 description = 'WASM based javascript wrapper for DIDComm'

--- a/wasm/demo/package.json
+++ b/wasm/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "didcomm-demo",
-  "version": "1.0.0",
+  "version": "0.4.0",
   "description": "JS demo for didcomm",
   "scripts": {
     "start": "ts-node src/main.ts",


### PR DESCRIPTION
Version number was previously bumped to 1.0.0, which was too high. Set it to 0.4.0 instead.