### PR TITLE
Refactor SecretsResolver to KMS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ features = ["v4"]
 [dev-dependencies]
 lazy_static = '1.4.0'
 
-[dev-dependencies.tokio]
+[dependencies.tokio]
 version = '1.9'
 features = [
     'rt',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ version = '1.9'
 features = [
     'rt',
     'macros',
+    'rt-multi-thread'
 ]
 
 [dev-dependencies.getrandom]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ let msg = Message::build(
 
 // --- Pack encrypted and authenticated message ---
 let did_resolver = ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
 let (msg, metadata) = msg
     .pack_encrypted(
@@ -110,7 +110,7 @@ let (msg, metadata) = msg
         Some(ALICE_DID),
         None,
         &did_resolver,
-        &secrets_resolver,
+        &kms,
         &PackEncryptedOptions::default(),
     )
     .await
@@ -123,12 +123,12 @@ println!("Sending message \n{}\n", msg);
 
 // --- Unpacking message ---
 let did_resolver = ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-let secrets_resolver = ExampleSecretsResolver::new(BOB_SECRETS.clone());
+let kms = ExampleSecretsResolver::new(BOB_SECRETS.clone());
 
 let (msg, metadata) = Message::unpack(
     &msg,
     &did_resolver,
-    &secrets_resolver,
+    &kms,
     &UnpackOptions::default(),
 )
 .await
@@ -147,7 +147,7 @@ let (msg, metadata) = msg
         None, // Keep sender as None here
         None,
         &did_resolver,
-        &secrets_resolver,
+        &kms,
         &PackEncryptedOptions::default(),
     )
     .await
@@ -163,7 +163,7 @@ let (msg, metadata) = msg
         Some(ALICE_DID),
         Some(ALICE_DID), // Provide information about signer here
         &did_resolver,
-        &secrets_resolver,
+        &kms,
         &PackEncryptedOptions::default(),
     )
     .await
@@ -194,7 +194,7 @@ let msg = Message::build(
 .finalize();
 
 let (msg, metadata) = msg
-    .pack_signed(ALICE_DID, &did_resolver, &secrets_resolver)
+    .pack_signed(ALICE_DID, &did_resolver, &kms)
     .await
     .expect("Unable pack_signed");
 
@@ -202,7 +202,7 @@ let (msg, metadata) = msg
 let (msg, metadata) = Message::unpack(
     &msg,
     &did_resolver,
-    &secrets_resolver,
+    &kms,
     &UnpackOptions::default(),
 )
 .await
@@ -237,7 +237,7 @@ let msg = msg
 let (msg, metadata) = Message::unpack(
     &msg,
     &did_resolver,
-    &secrets_resolver,
+    &kms,
     &UnpackOptions::default(),
 )
 .await

--- a/benches/pack_encrypted.rs
+++ b/benches/pack_encrypted.rs
@@ -8,8 +8,8 @@ mod test_vectors;
 use criterion::{async_executor::FuturesExecutor, criterion_group, criterion_main, Criterion};
 
 use didcomm::{
-    algorithms::AnonCryptAlg, did::resolvers::ExampleDIDResolver,
-    secrets::resolvers::ExampleSecretsResolver, PackEncryptedOptions,
+    algorithms::AnonCryptAlg, did::resolvers::ExampleDIDResolver, secrets::resolvers::ExampleKMS,
+    PackEncryptedOptions,
 };
 
 use test_vectors::{
@@ -24,11 +24,11 @@ async fn pack_encrypted(
     from: Option<&str>,
     sign_by: Option<&str>,
     did_resolver: &ExampleDIDResolver,
-    secrets_resolver: &ExampleSecretsResolver,
+    kms: &ExampleKMS,
     opts: &PackEncryptedOptions,
 ) {
     MESSAGE_SIMPLE
-        .pack_encrypted(to, from, sign_by, did_resolver, secrets_resolver, opts)
+        .pack_encrypted(to, from, sign_by, did_resolver, kms, opts)
         .await
         .expect("Unable pack_encrypted");
 }
@@ -42,7 +42,7 @@ fn benchmarks(c: &mut Criterion) {
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
 
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -50,9 +50,8 @@ fn benchmarks(c: &mut Criterion) {
         };
 
         c.bench_function("pack_encrypted_authcrypt_ed25519_1key", move |b| {
-            b.to_async(FuturesExecutor).iter(|| {
-                pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-            });
+            b.to_async(FuturesExecutor)
+                .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
         });
     }
 
@@ -64,7 +63,7 @@ fn benchmarks(c: &mut Criterion) {
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
 
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -76,9 +75,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_ed25519_1key_anoncrypt_a256cbc",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -89,7 +87,7 @@ fn benchmarks(c: &mut Criterion) {
         let sign_by = None;
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -101,9 +99,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_ed25519_1key_anoncrypt_a256gsm",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -114,7 +111,7 @@ fn benchmarks(c: &mut Criterion) {
         let sign_by = None;
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -126,9 +123,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_ed25519_1key_anoncrypt_xc20p",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -139,7 +135,7 @@ fn benchmarks(c: &mut Criterion) {
         let sign_by = None;
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -147,9 +143,8 @@ fn benchmarks(c: &mut Criterion) {
         };
 
         c.bench_function("pack_encrypted_authcrypt_ed25519_3keys", move |b| {
-            b.to_async(FuturesExecutor).iter(|| {
-                pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-            });
+            b.to_async(FuturesExecutor)
+                .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
         });
     }
 
@@ -161,7 +156,7 @@ fn benchmarks(c: &mut Criterion) {
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
 
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -173,9 +168,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_ed25519_3keys_anoncrypt_a256cbc",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -186,7 +180,7 @@ fn benchmarks(c: &mut Criterion) {
         let sign_by = None;
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -198,9 +192,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_ed25519_3keys_anoncrypt_a256gsm",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -211,7 +204,7 @@ fn benchmarks(c: &mut Criterion) {
         let sign_by = None;
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -223,9 +216,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_ed25519_3keys_anoncrypt_xc20p",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -236,7 +228,7 @@ fn benchmarks(c: &mut Criterion) {
         let sign_by = None;
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -246,9 +238,8 @@ fn benchmarks(c: &mut Criterion) {
         };
 
         c.bench_function("pack_encrypted_anoncrypt_ed25519_a256cbc_1key", move |b| {
-            b.to_async(FuturesExecutor).iter(|| {
-                pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-            });
+            b.to_async(FuturesExecutor)
+                .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
         });
     }
 
@@ -258,7 +249,7 @@ fn benchmarks(c: &mut Criterion) {
         let sign_by = None;
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -268,9 +259,8 @@ fn benchmarks(c: &mut Criterion) {
         };
 
         c.bench_function("pack_encrypted_anoncrypt_ed25519_a256gcm_1key", move |b| {
-            b.to_async(FuturesExecutor).iter(|| {
-                pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-            });
+            b.to_async(FuturesExecutor)
+                .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
         });
     }
 
@@ -280,7 +270,7 @@ fn benchmarks(c: &mut Criterion) {
         let sign_by = None;
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -290,9 +280,8 @@ fn benchmarks(c: &mut Criterion) {
         };
 
         c.bench_function("pack_encrypted_anoncrypt_ed25519_xc20p_1key", move |b| {
-            b.to_async(FuturesExecutor).iter(|| {
-                pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-            });
+            b.to_async(FuturesExecutor)
+                .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
         });
     }
 
@@ -302,7 +291,7 @@ fn benchmarks(c: &mut Criterion) {
         let sign_by = None;
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -310,9 +299,8 @@ fn benchmarks(c: &mut Criterion) {
         };
 
         c.bench_function("pack_encrypted_anoncrypt_ed25519_a256cbc_3keys", move |b| {
-            b.to_async(FuturesExecutor).iter(|| {
-                pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-            });
+            b.to_async(FuturesExecutor)
+                .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
         });
     }
 
@@ -322,7 +310,7 @@ fn benchmarks(c: &mut Criterion) {
         let sign_by = None;
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -332,9 +320,8 @@ fn benchmarks(c: &mut Criterion) {
         };
 
         c.bench_function("pack_encrypted_anoncrypt_ed25519_a256gsm_3keys", move |b| {
-            b.to_async(FuturesExecutor).iter(|| {
-                pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-            });
+            b.to_async(FuturesExecutor)
+                .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
         });
     }
 
@@ -344,7 +331,7 @@ fn benchmarks(c: &mut Criterion) {
         let sign_by = None;
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -354,9 +341,8 @@ fn benchmarks(c: &mut Criterion) {
         };
 
         c.bench_function("pack_encrypted_anoncrypt_ed25519_xc20p_3keys", move |b| {
-            b.to_async(FuturesExecutor).iter(|| {
-                pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-            });
+            b.to_async(FuturesExecutor)
+                .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
         });
     }
 
@@ -368,7 +354,7 @@ fn benchmarks(c: &mut Criterion) {
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
 
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -376,9 +362,8 @@ fn benchmarks(c: &mut Criterion) {
         };
 
         c.bench_function("pack_encrypted_authcrypt_p256_1key", move |b| {
-            b.to_async(FuturesExecutor).iter(|| {
-                pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-            });
+            b.to_async(FuturesExecutor)
+                .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
         });
     }
 
@@ -390,7 +375,7 @@ fn benchmarks(c: &mut Criterion) {
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
 
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -402,9 +387,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_p256_1key_anoncrypt_a256cbc",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -415,7 +399,7 @@ fn benchmarks(c: &mut Criterion) {
         let sign_by = None;
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -427,9 +411,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_p256_1key_anoncrypt_a256gsm",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -440,7 +423,7 @@ fn benchmarks(c: &mut Criterion) {
         let sign_by = None;
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -452,9 +435,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_p256_1key_anoncrypt_xc20p",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -467,7 +449,7 @@ fn benchmarks(c: &mut Criterion) {
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
 
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -477,9 +459,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_ed25519_1key_sign_x25519",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -492,7 +473,7 @@ fn benchmarks(c: &mut Criterion) {
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
 
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -502,9 +483,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_ed25519_1key_sign_p256",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -517,7 +497,7 @@ fn benchmarks(c: &mut Criterion) {
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
 
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -527,9 +507,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_ed25519_1key_sign_k256",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -542,7 +521,7 @@ fn benchmarks(c: &mut Criterion) {
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
 
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -554,9 +533,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_ed25519_1key_anoncrypt_a256cbc_sign_x25519",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -569,7 +547,7 @@ fn benchmarks(c: &mut Criterion) {
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
 
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -581,9 +559,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_ed25519_1key_anoncrypt_a256cbc_sign_p256",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -596,7 +573,7 @@ fn benchmarks(c: &mut Criterion) {
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
 
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -608,9 +585,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_ed25519_1key_anoncrypt_a256cbc_sign_k256",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -623,7 +599,7 @@ fn benchmarks(c: &mut Criterion) {
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
 
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -635,9 +611,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_p256_1key_anoncrypt_a256cbc_sign_e25519",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -650,7 +625,7 @@ fn benchmarks(c: &mut Criterion) {
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
 
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -662,9 +637,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_p256_1key_anoncrypt_a256cbc_sign_p256",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }
@@ -677,7 +651,7 @@ fn benchmarks(c: &mut Criterion) {
         let did_resolver =
             ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
 
-        let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+        let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
         let opts = PackEncryptedOptions {
             forward: false,
@@ -689,9 +663,8 @@ fn benchmarks(c: &mut Criterion) {
         c.bench_function(
             "pack_encrypted_authcrypt_p256_1key_anoncrypt_a256cbc_sign_k256",
             move |b| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    pack_encrypted(to, from, sign_by, &did_resolver, &secrets_resolver, &opts)
-                });
+                b.to_async(FuturesExecutor)
+                    .iter(|| pack_encrypted(to, from, sign_by, &did_resolver, &kms, &opts));
             },
         );
     }

--- a/benches/pack_signed.rs
+++ b/benches/pack_signed.rs
@@ -6,7 +6,7 @@ pub(crate) use didcomm;
 mod test_vectors;
 
 use criterion::{async_executor::FuturesExecutor, criterion_group, criterion_main, Criterion};
-use didcomm::{did::resolvers::ExampleDIDResolver, secrets::resolvers::ExampleSecretsResolver};
+use didcomm::{did::resolvers::ExampleDIDResolver, secrets::resolvers::ExampleKMS};
 
 use test_vectors::{
     ALICE_AUTH_METHOD_25519, ALICE_AUTH_METHOD_P256, ALICE_AUTH_METHOD_SECPP256K1, ALICE_DID_DOC,
@@ -14,13 +14,9 @@ use test_vectors::{
 };
 
 // Here we have an async function to benchmark
-async fn pack_signed(
-    sign_by: &str,
-    did_resolver: &ExampleDIDResolver,
-    secrets_resolver: &ExampleSecretsResolver,
-) {
+async fn pack_signed(sign_by: &str, did_resolver: &ExampleDIDResolver, kms: &ExampleKMS) {
     MESSAGE_SIMPLE
-        .pack_signed(sign_by, did_resolver, secrets_resolver)
+        .pack_signed(sign_by, did_resolver, kms)
         .await
         .expect("Unable pack_signed");
 }
@@ -28,29 +24,29 @@ async fn pack_signed(
 fn benchmarks(c: &mut Criterion) {
     let sign_by = &ALICE_AUTH_METHOD_25519.id;
     let did_resolver = ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone()]);
-    let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+    let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
     c.bench_function("pack_signed_ed25519", move |b| {
         b.to_async(FuturesExecutor)
-            .iter(|| pack_signed(sign_by, &did_resolver, &secrets_resolver));
+            .iter(|| pack_signed(sign_by, &did_resolver, &kms));
     });
 
     let sign_by = &ALICE_AUTH_METHOD_P256.id;
     let did_resolver = ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone()]);
-    let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+    let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
     c.bench_function("pack_signed_p256", move |b| {
         b.to_async(FuturesExecutor)
-            .iter(|| pack_signed(sign_by, &did_resolver, &secrets_resolver));
+            .iter(|| pack_signed(sign_by, &did_resolver, &kms));
     });
 
     let sign_by = &ALICE_AUTH_METHOD_SECPP256K1.id;
     let did_resolver = ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone()]);
-    let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+    let kms = ExampleKMS::new(ALICE_SECRETS.clone());
 
     c.bench_function("pack_signed_k256", move |b| {
         b.to_async(FuturesExecutor)
-            .iter(|| pack_signed(sign_by, &did_resolver, &secrets_resolver));
+            .iter(|| pack_signed(sign_by, &did_resolver, &kms));
     });
 }
 

--- a/examples/advanced_params.rs
+++ b/examples/advanced_params.rs
@@ -13,7 +13,7 @@ use didcomm::{
     secrets::resolvers::ExampleSecretsResolver,
     Message, PackEncryptedOptions, UnpackOptions,
 };
-use serde_json::json;
+use serde_json::{json, Number, Value};
 use std::collections::HashMap;
 use std::iter::FromIterator;
 use test_vectors::{
@@ -33,6 +33,8 @@ async fn main() {
     .to(BOB_DID.to_owned())
     .created_time(1516269022)
     .expires_time(1516385931)
+    .header("bla1".parse().unwrap(), Value::Bool(false))
+    .header("bla2".parse().unwrap(), Value::Number(Number::from(12)))
     .finalize();
 
     // --- Packing encrypted and authenticated message ---

--- a/examples/attachments.rs
+++ b/examples/attachments.rs
@@ -8,8 +8,8 @@ pub(crate) use didcomm;
 
 use didcomm::{
     did::resolvers::ExampleDIDResolver, protocols::routing::try_parse_forward,
-    secrets::resolvers::ExampleSecretsResolver, Attachment, AttachmentData, JsonAttachmentData,
-    Message, PackEncryptedOptions, UnpackOptions,
+    secrets::resolvers::ExampleKMS, Attachment, AttachmentData, JsonAttachmentData, Message,
+    PackEncryptedOptions, UnpackOptions,
 };
 use serde_json::json;
 use test_vectors::{
@@ -51,7 +51,7 @@ async fn main() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(ALICE_SECRETS.clone());
 
     let (msg, metadata) = msg
         .pack_encrypted(
@@ -77,7 +77,7 @@ async fn main() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR1_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR1_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -107,7 +107,7 @@ async fn main() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(BOB_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(BOB_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -8,7 +8,7 @@ pub(crate) use didcomm;
 
 use didcomm::{
     did::resolvers::ExampleDIDResolver, protocols::routing::try_parse_forward,
-    secrets::resolvers::ExampleSecretsResolver, Message, PackEncryptedOptions, UnpackOptions,
+    secrets::resolvers::ExampleKMS, Message, PackEncryptedOptions, UnpackOptions,
 };
 use serde_json::json;
 use test_vectors::{
@@ -51,7 +51,7 @@ async fn non_repudiable_encryption() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(ALICE_SECRETS.clone());
 
     let (msg, metadata) = msg
         .pack_encrypted(
@@ -77,7 +77,7 @@ async fn non_repudiable_encryption() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR1_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR1_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -107,7 +107,7 @@ async fn non_repudiable_encryption() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(BOB_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(BOB_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -143,7 +143,7 @@ async fn multi_recipient() {
         MEDIATOR3_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(ALICE_SECRETS.clone());
 
     let (msg_bob, metadata_bob) = msg
         .pack_encrypted(
@@ -193,7 +193,7 @@ async fn multi_recipient() {
         MEDIATOR3_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR1_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR1_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg_bob,
@@ -226,7 +226,7 @@ async fn multi_recipient() {
         MEDIATOR3_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(BOB_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(BOB_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -250,7 +250,7 @@ async fn multi_recipient() {
         MEDIATOR3_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR3_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR3_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg_charlie,
@@ -283,7 +283,7 @@ async fn multi_recipient() {
         MEDIATOR3_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR2_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR2_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -316,7 +316,7 @@ async fn multi_recipient() {
         MEDIATOR3_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR1_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR1_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -349,7 +349,7 @@ async fn multi_recipient() {
         MEDIATOR3_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(CHARLIE_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(CHARLIE_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -386,7 +386,7 @@ async fn repudiable_authenticated_encryption() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(ALICE_SECRETS.clone());
 
     let (msg, metadata) = msg
         .pack_encrypted(
@@ -412,7 +412,7 @@ async fn repudiable_authenticated_encryption() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR1_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR1_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -442,7 +442,7 @@ async fn repudiable_authenticated_encryption() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(BOB_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(BOB_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -475,7 +475,7 @@ async fn repudiable_non_authenticated_encryption() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(vec![]);
+    let secrets_resolver = ExampleKMS::new(vec![]);
 
     let (msg, metadata) = msg
         .pack_encrypted(
@@ -501,7 +501,7 @@ async fn repudiable_non_authenticated_encryption() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR1_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR1_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -531,7 +531,7 @@ async fn repudiable_non_authenticated_encryption() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(BOB_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(BOB_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -559,7 +559,7 @@ async fn signed_unencrypted() {
 
     // --- Packing signed message ---
     let did_resolver = ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-    let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(ALICE_SECRETS.clone());
 
     let (msg, metadata) = msg
         .pack_signed(ALICE_DID, &did_resolver, &secrets_resolver)
@@ -573,7 +573,7 @@ async fn signed_unencrypted() {
 
     // --- Unpacking message ---
     let did_resolver = ExampleDIDResolver::new(vec![ALICE_DID_DOC.clone(), BOB_DID_DOC.clone()]);
-    let secrets_resolver = ExampleSecretsResolver::new(vec![]);
+    let secrets_resolver = ExampleKMS::new(vec![]);
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -612,7 +612,7 @@ async fn plaintext_unencrypted() {
 
     // --- Unpacking message ---
     let did_resolver = ExampleDIDResolver::new(vec![]);
-    let secrets_resolver = ExampleSecretsResolver::new(vec![]);
+    let secrets_resolver = ExampleKMS::new(vec![]);
 
     let (msg, metadata) = Message::unpack(
         &msg,

--- a/examples/rotate_did.rs
+++ b/examples/rotate_did.rs
@@ -8,8 +8,7 @@ pub(crate) use didcomm;
 
 use didcomm::{
     did::resolvers::ExampleDIDResolver, protocols::routing::try_parse_forward,
-    secrets::resolvers::ExampleSecretsResolver, FromPrior, Message, PackEncryptedOptions,
-    UnpackOptions,
+    secrets::resolvers::ExampleKMS, FromPrior, Message, PackEncryptedOptions, UnpackOptions,
 };
 use serde_json::json;
 use test_vectors::{
@@ -26,7 +25,7 @@ async fn main() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(CHARLIE_ROTATED_TO_ALICE_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(CHARLIE_ROTATED_TO_ALICE_SECRETS.clone());
 
     // --- Building from_prior header
     let from_prior = FromPrior::build(CHARLIE_DID.into(), ALICE_DID.into())
@@ -88,7 +87,7 @@ async fn main() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR1_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR1_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -119,7 +118,7 @@ async fn main() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(BOB_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(BOB_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,

--- a/examples/routing.rs
+++ b/examples/routing.rs
@@ -10,7 +10,7 @@ use didcomm::{
     algorithms::AnonCryptAlg,
     did::resolvers::ExampleDIDResolver,
     protocols::routing::{try_parse_forward, wrap_in_forward},
-    secrets::resolvers::ExampleSecretsResolver,
+    secrets::resolvers::ExampleKMS,
     Message, PackEncryptedOptions, UnpackOptions,
 };
 use serde_json::json;
@@ -55,7 +55,7 @@ async fn single_mediator() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(ALICE_SECRETS.clone());
 
     let (msg, metadata) = msg
         .pack_encrypted(
@@ -81,7 +81,7 @@ async fn single_mediator() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR1_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR1_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -111,7 +111,7 @@ async fn single_mediator() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(BOB_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(BOB_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -146,7 +146,7 @@ async fn multiple_mediators_with_alternative_endpoints() {
         MEDIATOR3_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(ALICE_SECRETS.clone());
 
     let (msg, metadata) = msg
         .pack_encrypted(
@@ -174,7 +174,7 @@ async fn multiple_mediators_with_alternative_endpoints() {
         MEDIATOR3_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR3_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR3_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -206,7 +206,7 @@ async fn multiple_mediators_with_alternative_endpoints() {
         MEDIATOR3_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR2_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR2_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -238,7 +238,7 @@ async fn multiple_mediators_with_alternative_endpoints() {
         MEDIATOR3_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR1_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR1_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -270,7 +270,7 @@ async fn multiple_mediators_with_alternative_endpoints() {
         MEDIATOR3_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(CHARLIE_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(CHARLIE_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -306,7 +306,7 @@ async fn re_wrapping_for_final_recipient() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(ALICE_SECRETS.clone());
 
     let (msg, metadata) = msg
         .pack_encrypted(
@@ -332,7 +332,7 @@ async fn re_wrapping_for_final_recipient() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR1_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR1_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -380,7 +380,7 @@ async fn re_wrapping_for_final_recipient() {
         MEDIATOR1_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(BOB_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(BOB_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -414,7 +414,7 @@ async fn re_wrapping_for_mediator_unknown_to_sender() {
         MEDIATOR2_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(ALICE_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(ALICE_SECRETS.clone());
 
     let (msg, metadata) = msg
         .pack_encrypted(
@@ -441,7 +441,7 @@ async fn re_wrapping_for_mediator_unknown_to_sender() {
         MEDIATOR2_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR1_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR1_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -490,7 +490,7 @@ async fn re_wrapping_for_mediator_unknown_to_sender() {
         MEDIATOR2_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(MEDIATOR2_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(MEDIATOR2_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,
@@ -520,7 +520,7 @@ async fn re_wrapping_for_mediator_unknown_to_sender() {
         MEDIATOR2_DID_DOC.clone(),
     ]);
 
-    let secrets_resolver = ExampleSecretsResolver::new(BOB_SECRETS.clone());
+    let secrets_resolver = ExampleKMS::new(BOB_SECRETS.clone());
 
     let (msg, metadata) = Message::unpack(
         &msg,

--- a/src/jwe/decrypt.rs
+++ b/src/jwe/decrypt.rs
@@ -19,7 +19,7 @@ impl<'a, 'b> ParsedJWE<'a, 'b> {
         sender: Option<(&str, &'a KE)>,
         recipient: (
             &'a str,
-            impl FnOnce(KE, Option<KE>, &'a str, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) -> FUT,
+            impl FnOnce(KE, Option<KE>, String, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) -> FUT,
         ),
     ) -> Result<Vec<u8>>
     where
@@ -62,7 +62,7 @@ impl<'a, 'b> ParsedJWE<'a, 'b> {
         let kw = derive_func(
             epk,
             skey.cloned(),
-            kid,
+            kid.to_string(),
             self.protected.alg.as_str().as_bytes().to_vec(),
             self.apu.as_deref().unwrap_or(&[]).to_vec(),
             self.apv.to_vec(),
@@ -1038,7 +1038,7 @@ mod tests {
 
         let derive_func = |ephem_key: KE,
                            sender_key: Option<KE>,
-                           recip_kid: &str,
+                           _recip_kid: String,
                            alg: Vec<u8>,
                            apu: Vec<u8>,
                            apv: Vec<u8>,

--- a/src/jwe/encrypt.rs
+++ b/src/jwe/encrypt.rs
@@ -490,7 +490,7 @@ mod tests {
                             bob_edge_priv.0,
                             |ephem_key: KE,
                              sender_key: Option<KE>,
-                             recip_kid: &str,
+                             _recip_kid: String,
                              alg: Vec<u8>,
                              apu: Vec<u8>,
                              apv: Vec<u8>,

--- a/src/jwe/encrypt.rs
+++ b/src/jwe/encrypt.rs
@@ -456,7 +456,30 @@ mod tests {
                     .expect("recipient not found.");
 
                 let plaintext_ = msg
-                    .decrypt::<CE, KDF, KE, KW>(alice_pub, *bob_edge_priv)
+                    .decrypt::<CE, KDF, KE, KW>(
+                        alice_pub,
+                        (
+                            bob_edge_priv.0,
+                            |ephem_key: &KE,
+                             sender_key: Option<&KE>,
+                             recip_kid: &str,
+                             alg: &[u8],
+                             apu: &[u8],
+                             apv: &[u8],
+                             cc_tag: &[u8]| {
+                                KDF::derive_key(
+                                    ephem_key,
+                                    sender_key,
+                                    &bob_edge_priv.1,
+                                    alg,
+                                    apu,
+                                    apv,
+                                    cc_tag,
+                                    true,
+                                )
+                            },
+                        ),
+                    )
                     .expect("unable decrypt.");
 
                 assert_eq!(plaintext_, plaintext.as_bytes());

--- a/src/jws/mod.rs
+++ b/src/jws/mod.rs
@@ -31,8 +31,8 @@ mod tests {
     use askar_crypto::{alg::ed25519::Ed25519KeyPair, jwk::FromJwk};
 
     use crate::jws::{self, Algorithm};
-    use crate::secrets::resolvers::ExampleSecretsResolver;
-    use crate::secrets::{Secret, SecretMaterial, SecretType};
+    use crate::secrets::resolvers::example::{Secret, SecretMaterial, SecretType};
+    use crate::secrets::resolvers::ExampleKMS;
 
     #[tokio::test]
     async fn demo_works() {
@@ -57,7 +57,7 @@ mod tests {
                 .expect("Unable from_jwk"),
             },
         };
-        let kms = ExampleSecretsResolver::new(vec![alice_secret]);
+        let kms = ExampleKMS::new(vec![alice_secret]);
 
         // Alice public key
         let alice_pkey = Ed25519KeyPair::from_jwk(

--- a/src/jws/sign.rs
+++ b/src/jws/sign.rs
@@ -1,7 +1,6 @@
-use askar_crypto::sign::KeySign;
 use std::borrow::Cow;
 
-use crate::secrets::SecretsResolver;
+use crate::secrets::KeyManagementService;
 use crate::{
     error::{ErrorKind, Result, ResultExt},
     jws::envelope::{Algorithm, CompactHeader, Header, ProtectedHeader, Signature, JWS},
@@ -11,7 +10,7 @@ pub(crate) async fn sign(
     payload: &[u8],
     kid: &str,
     alg: Algorithm,
-    kms: &dyn SecretsResolver,
+    kms: &dyn KeyManagementService,
 ) -> Result<String> {
     let sig_type = alg.sig_type()?;
 
@@ -64,7 +63,7 @@ pub(crate) async fn sign_compact(
     kid: &str,
     typ: &str,
     alg: Algorithm,
-    kms: &dyn SecretsResolver,
+    kms: &dyn KeyManagementService,
 ) -> Result<String> {
     let sig_type = alg.sig_type()?;
 
@@ -104,10 +103,9 @@ mod tests {
         jwk::FromJwk,
         sign::{KeySigVerify, KeySign},
     };
-    use serde_json::json;
 
-    use crate::secrets::resolvers::ExampleSecretsResolver;
-    use crate::secrets::{Secret, SecretMaterial, SecretType};
+    use crate::secrets::resolvers::example::{Secret, SecretMaterial, SecretType};
+    use crate::secrets::resolvers::ExampleKMS;
     use crate::{
         error::{ErrorKind, Result},
         jws::{self, envelope::Algorithm},
@@ -475,7 +473,7 @@ mod tests {
                 private_key_jwk: serde_json::from_str(key)?,
             },
         };
-        let kms = ExampleSecretsResolver::new(vec![secret]);
+        let kms = ExampleKMS::new(vec![secret]);
         jws::sign(payload.as_bytes(), kid, alg.clone(), &kms).await
     }
 
@@ -493,7 +491,7 @@ mod tests {
                 private_key_jwk: serde_json::from_str(key)?,
             },
         };
-        let kms = ExampleSecretsResolver::new(vec![secret]);
+        let kms = ExampleKMS::new(vec![secret]);
         jws::sign_compact(payload.as_bytes(), kid, typ, alg.clone(), &kms).await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ mod tests {
     use serde_json::json;
 
     use crate::{
-        did::resolvers::ExampleDIDResolver, secrets::resolvers::ExampleSecretsResolver, Message,
+        did::resolvers::ExampleDIDResolver, secrets::resolvers::ExampleKMS, Message,
         PackEncryptedOptions, UnpackOptions,
     };
 
@@ -58,7 +58,7 @@ mod tests {
         // --- Packing message ---
 
         let sender_did_resolver = ExampleDIDResolver::new(vec![]);
-        let sender_secrets_resolver = ExampleSecretsResolver::new(vec![]);
+        let sender_kms = ExampleKMS::new(vec![]);
 
         let (packed_msg, metadata) = msg
             .pack_encrypted(
@@ -66,7 +66,7 @@ mod tests {
                 Some(sender),
                 None,
                 &sender_did_resolver,
-                &sender_secrets_resolver,
+                &sender_kms,
                 &PackEncryptedOptions::default(),
             )
             .await
@@ -84,12 +84,12 @@ mod tests {
         // --- Unpacking message ---
 
         let recipient_did_resolver = ExampleDIDResolver::new(vec![]);
-        let recipient_secrets_resolver = ExampleSecretsResolver::new(vec![]);
+        let recipient_kms = ExampleKMS::new(vec![]);
 
         let (msg, metadata) = Message::unpack(
             &packed_msg,
             &recipient_did_resolver,
-            &recipient_secrets_resolver,
+            &recipient_kms,
             &UnpackOptions::default(),
         )
         .await

--- a/src/message/pack_encrypted/anoncrypt.rs
+++ b/src/message/pack_encrypted/anoncrypt.rs
@@ -110,7 +110,18 @@ pub(crate) async fn anoncrypt<'dr, 'sr>(
                     msg,
                     jwe::Algorithm::EcdhEsA256kw,
                     jwe::EncAlgorithm::A256cbcHs512,
-                    None,
+                    None::<(
+                        &str,
+                        fn(
+                            &X25519KeyPair,
+                            Option<&str>,
+                            &X25519KeyPair,
+                            &[u8],
+                            &[u8],
+                            &[u8],
+                            &[u8],
+                        ) -> Result<AesKey<A256Kw>>,
+                    )>,
                     &to_keys,
                 )
                 .context("Unable produce anoncrypt envelope")?,
@@ -123,7 +134,18 @@ pub(crate) async fn anoncrypt<'dr, 'sr>(
                     msg,
                     jwe::Algorithm::EcdhEsA256kw,
                     jwe::EncAlgorithm::Xc20P,
-                    None,
+                    None::<(
+                        &str,
+                        fn(
+                            &X25519KeyPair,
+                            Option<&str>,
+                            &X25519KeyPair,
+                            &[u8],
+                            &[u8],
+                            &[u8],
+                            &[u8],
+                        ) -> Result<AesKey<A256Kw>>,
+                    )>,
                     &to_keys,
                 )
                 .context("Unable produce anoncrypt envelope")?,
@@ -136,7 +158,18 @@ pub(crate) async fn anoncrypt<'dr, 'sr>(
                     msg,
                     jwe::Algorithm::EcdhEsA256kw,
                     jwe::EncAlgorithm::A256Gcm,
-                    None,
+                    None::<(
+                        &str,
+                        fn(
+                            &X25519KeyPair,
+                            Option<&str>,
+                            &X25519KeyPair,
+                            &[u8],
+                            &[u8],
+                            &[u8],
+                            &[u8],
+                        ) -> Result<AesKey<A256Kw>>,
+                    )>,
                     &to_keys,
                 )
                 .context("Unable produce anoncrypt envelope")?,
@@ -163,7 +196,18 @@ pub(crate) async fn anoncrypt<'dr, 'sr>(
                     msg,
                     jwe::Algorithm::EcdhEsA256kw,
                     jwe::EncAlgorithm::A256cbcHs512,
-                    None,
+                    None::<(
+                        &str,
+                        fn(
+                            &P256KeyPair,
+                            Option<&str>,
+                            &P256KeyPair,
+                            &[u8],
+                            &[u8],
+                            &[u8],
+                            &[u8],
+                        ) -> Result<AesKey<A256Kw>>,
+                    )>,
                     &to_keys,
                 )
                 .context("Unable produce anoncrypt envelope")?,
@@ -176,7 +220,18 @@ pub(crate) async fn anoncrypt<'dr, 'sr>(
                     msg,
                     jwe::Algorithm::EcdhEsA256kw,
                     jwe::EncAlgorithm::Xc20P,
-                    None,
+                    None::<(
+                        &str,
+                        fn(
+                            &P256KeyPair,
+                            Option<&str>,
+                            &P256KeyPair,
+                            &[u8],
+                            &[u8],
+                            &[u8],
+                            &[u8],
+                        ) -> Result<AesKey<A256Kw>>,
+                    )>,
                     &to_keys,
                 )
                 .context("Unable produce anoncrypt envelope")?,
@@ -189,7 +244,18 @@ pub(crate) async fn anoncrypt<'dr, 'sr>(
                     msg,
                     jwe::Algorithm::EcdhEsA256kw,
                     jwe::EncAlgorithm::A256Gcm,
-                    None,
+                    None::<(
+                        &str,
+                        fn(
+                            &P256KeyPair,
+                            Option<&str>,
+                            &P256KeyPair,
+                            &[u8],
+                            &[u8],
+                            &[u8],
+                            &[u8],
+                        ) -> Result<AesKey<A256Kw>>,
+                    )>,
                     &to_keys,
                 )
                 .context("Unable produce anoncrypt envelope")?,

--- a/src/message/pack_encrypted/anoncrypt.rs
+++ b/src/message/pack_encrypted/anoncrypt.rs
@@ -8,6 +8,7 @@ use askar_crypto::{
     kdf::ecdh_es::EcdhEs,
 };
 
+use crate::utils::DummyFuture;
 use crate::{
     algorithms::AnonCryptAlg,
     did::DIDResolver,
@@ -106,6 +107,7 @@ pub(crate) async fn anoncrypt<'dr, 'sr>(
                     EcdhEs<'_, X25519KeyPair>,
                     X25519KeyPair,
                     AesKey<A256Kw>,
+                    _,
                 >(
                     msg,
                     jwe::Algorithm::EcdhEsA256kw,
@@ -113,23 +115,25 @@ pub(crate) async fn anoncrypt<'dr, 'sr>(
                     None::<(
                         &str,
                         fn(
-                            &X25519KeyPair,
-                            Option<&str>,
-                            &X25519KeyPair,
-                            &[u8],
-                            &[u8],
-                            &[u8],
-                            &[u8],
-                        ) -> Result<AesKey<A256Kw>>,
+                            X25519KeyPair,
+                            Option<String>,
+                            X25519KeyPair,
+                            Vec<u8>,
+                            Vec<u8>,
+                            Vec<u8>,
+                            Vec<u8>,
+                        ) -> DummyFuture<Result<AesKey<A256Kw>>>,
                     )>,
                     &to_keys,
                 )
+                .await
                 .context("Unable produce anoncrypt envelope")?,
                 AnonCryptAlg::Xc20pEcdhEsA256kw => jwe::encrypt::<
                     Chacha20Key<XC20P>,
                     EcdhEs<'_, X25519KeyPair>,
                     X25519KeyPair,
                     AesKey<A256Kw>,
+                    _,
                 >(
                     msg,
                     jwe::Algorithm::EcdhEsA256kw,
@@ -137,23 +141,25 @@ pub(crate) async fn anoncrypt<'dr, 'sr>(
                     None::<(
                         &str,
                         fn(
-                            &X25519KeyPair,
-                            Option<&str>,
-                            &X25519KeyPair,
-                            &[u8],
-                            &[u8],
-                            &[u8],
-                            &[u8],
-                        ) -> Result<AesKey<A256Kw>>,
+                            X25519KeyPair,
+                            Option<String>,
+                            X25519KeyPair,
+                            Vec<u8>,
+                            Vec<u8>,
+                            Vec<u8>,
+                            Vec<u8>,
+                        ) -> DummyFuture<Result<AesKey<A256Kw>>>,
                     )>,
                     &to_keys,
                 )
+                .await
                 .context("Unable produce anoncrypt envelope")?,
                 AnonCryptAlg::A256gcmEcdhEsA256kw => jwe::encrypt::<
                     AesKey<A256Gcm>,
                     EcdhEs<'_, X25519KeyPair>,
                     X25519KeyPair,
                     AesKey<A256Kw>,
+                    _,
                 >(
                     msg,
                     jwe::Algorithm::EcdhEsA256kw,
@@ -161,17 +167,18 @@ pub(crate) async fn anoncrypt<'dr, 'sr>(
                     None::<(
                         &str,
                         fn(
-                            &X25519KeyPair,
-                            Option<&str>,
-                            &X25519KeyPair,
-                            &[u8],
-                            &[u8],
-                            &[u8],
-                            &[u8],
-                        ) -> Result<AesKey<A256Kw>>,
+                            X25519KeyPair,
+                            Option<String>,
+                            X25519KeyPair,
+                            Vec<u8>,
+                            Vec<u8>,
+                            Vec<u8>,
+                            Vec<u8>,
+                        ) -> DummyFuture<Result<AesKey<A256Kw>>>,
                     )>,
                     &to_keys,
                 )
+                .await
                 .context("Unable produce anoncrypt envelope")?,
             }
         }
@@ -192,6 +199,7 @@ pub(crate) async fn anoncrypt<'dr, 'sr>(
                     EcdhEs<'_, P256KeyPair>,
                     P256KeyPair,
                     AesKey<A256Kw>,
+                    _,
                 >(
                     msg,
                     jwe::Algorithm::EcdhEsA256kw,
@@ -199,23 +207,25 @@ pub(crate) async fn anoncrypt<'dr, 'sr>(
                     None::<(
                         &str,
                         fn(
-                            &P256KeyPair,
-                            Option<&str>,
-                            &P256KeyPair,
-                            &[u8],
-                            &[u8],
-                            &[u8],
-                            &[u8],
-                        ) -> Result<AesKey<A256Kw>>,
+                            P256KeyPair,
+                            Option<String>,
+                            P256KeyPair,
+                            Vec<u8>,
+                            Vec<u8>,
+                            Vec<u8>,
+                            Vec<u8>,
+                        ) -> DummyFuture<Result<AesKey<A256Kw>>>,
                     )>,
                     &to_keys,
                 )
+                .await
                 .context("Unable produce anoncrypt envelope")?,
                 AnonCryptAlg::Xc20pEcdhEsA256kw => jwe::encrypt::<
                     Chacha20Key<XC20P>,
                     EcdhEs<'_, P256KeyPair>,
                     P256KeyPair,
                     AesKey<A256Kw>,
+                    _,
                 >(
                     msg,
                     jwe::Algorithm::EcdhEsA256kw,
@@ -223,23 +233,25 @@ pub(crate) async fn anoncrypt<'dr, 'sr>(
                     None::<(
                         &str,
                         fn(
-                            &P256KeyPair,
-                            Option<&str>,
-                            &P256KeyPair,
-                            &[u8],
-                            &[u8],
-                            &[u8],
-                            &[u8],
-                        ) -> Result<AesKey<A256Kw>>,
+                            P256KeyPair,
+                            Option<String>,
+                            P256KeyPair,
+                            Vec<u8>,
+                            Vec<u8>,
+                            Vec<u8>,
+                            Vec<u8>,
+                        ) -> DummyFuture<Result<AesKey<A256Kw>>>,
                     )>,
                     &to_keys,
                 )
+                .await
                 .context("Unable produce anoncrypt envelope")?,
                 AnonCryptAlg::A256gcmEcdhEsA256kw => jwe::encrypt::<
                     AesKey<A256Gcm>,
                     EcdhEs<'_, P256KeyPair>,
                     P256KeyPair,
                     AesKey<A256Kw>,
+                    _,
                 >(
                     msg,
                     jwe::Algorithm::EcdhEsA256kw,
@@ -247,17 +259,18 @@ pub(crate) async fn anoncrypt<'dr, 'sr>(
                     None::<(
                         &str,
                         fn(
-                            &P256KeyPair,
-                            Option<&str>,
-                            &P256KeyPair,
-                            &[u8],
-                            &[u8],
-                            &[u8],
-                            &[u8],
-                        ) -> Result<AesKey<A256Kw>>,
+                            P256KeyPair,
+                            Option<String>,
+                            P256KeyPair,
+                            Vec<u8>,
+                            Vec<u8>,
+                            Vec<u8>,
+                            Vec<u8>,
+                        ) -> DummyFuture<Result<AesKey<A256Kw>>>,
                     )>,
                     &to_keys,
                 )
+                .await
                 .context("Unable produce anoncrypt envelope")?,
             }
         }

--- a/src/message/pack_encrypted/authcrypt.rs
+++ b/src/message/pack_encrypted/authcrypt.rs
@@ -18,7 +18,7 @@ use askar_crypto::{
     },
     kdf::{ecdh_1pu::Ecdh1PU, ecdh_es::EcdhEs},
 };
-use tokio::runtime::Runtime;
+use tokio::runtime::Handle;
 
 pub(crate) async fn authcrypt<'dr, 'sr>(
     to: &str,
@@ -197,7 +197,7 @@ pub(crate) async fn authcrypt<'dr, 'sr>(
                                 err_msg(ErrorKind::InvalidState, "No sender key for ecdh-1pu")
                             })?;
 
-                            Runtime::new().unwrap().block_on(
+                            Handle::current().block_on(
                                 secrets_resolver.derive_aes_key_from_x25519_using_edch1pu(
                                     ephem_key, send_kid, recip_key, alg, apu, apv, cc_tag, false,
                                 ),
@@ -322,7 +322,7 @@ pub(crate) async fn authcrypt<'dr, 'sr>(
                                 err_msg(ErrorKind::InvalidState, "No sender key for ecdh-1pu")
                             })?;
 
-                            Runtime::new().unwrap().block_on(
+                            Handle::current().block_on(
                                 secrets_resolver.derive_aes_key_from_p256_using_edch1pu(
                                     ephem_key, send_kid, recip_key, alg, apu, apv, cc_tag, false,
                                 ),

--- a/src/message/pack_encrypted/mod.rs
+++ b/src/message/pack_encrypted/mod.rs
@@ -1,10 +1,9 @@
 mod anoncrypt;
 mod authcrypt;
 
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 
 use crate::{
     algorithms::{AnonCryptAlg, AuthCryptAlg},
@@ -450,7 +449,7 @@ mod tests {
         ) where
             CE: KeyAeadInPlace + KeySecretBytes,
             KDF: JoseKDF<KE, KW>,
-            KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue,
+            KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue + Clone,
             KW: KeyWrap + FromKeyDerivation,
         {
             let did_resolver =
@@ -483,7 +482,7 @@ mod tests {
                 }
             );
 
-            let msg = _verify_authcrypt::<CE, KDF, KE, KW>(&msg, to_keys, from_key);
+            let msg = _verify_authcrypt::<CE, KDF, KE, KW>(&msg, to_keys, from_key).await;
             _verify_plaintext(&msg, PLAINTEXT_MSG_SIMPLE);
         }
     }
@@ -764,11 +763,11 @@ mod tests {
         ) where
             CE: KeyAeadInPlace + KeySecretBytes,
             KDF: JoseKDF<KE, KW>,
-            KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue,
+            KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue + Clone,
             KW: KeyWrap + FromKeyDerivation,
             ACE: KeyAeadInPlace + KeySecretBytes,
             AKDF: JoseKDF<AKE, AKW>,
-            AKE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue,
+            AKE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue + Clone,
             AKW: KeyWrap + FromKeyDerivation,
         {
             let did_resolver =
@@ -804,8 +803,9 @@ mod tests {
             );
 
             let msg =
-                _verify_anoncrypt::<ACE, AKDF, AKE, AKW>(&msg, to_keys.clone(), enc_alg_anon_jwe);
-            let msg = _verify_authcrypt::<CE, KDF, KE, KW>(&msg, to_keys, from_key);
+                _verify_anoncrypt::<ACE, AKDF, AKE, AKW>(&msg, to_keys.clone(), enc_alg_anon_jwe)
+                    .await;
+            let msg = _verify_authcrypt::<CE, KDF, KE, KW>(&msg, to_keys, from_key).await;
             _verify_plaintext(&msg, PLAINTEXT_MSG_SIMPLE);
         }
     }
@@ -914,11 +914,11 @@ mod tests {
         ) where
             CE: KeyAeadInPlace + KeySecretBytes,
             KDF: JoseKDF<KE, KW>,
-            KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue,
+            KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue + Clone,
             KW: KeyWrap + FromKeyDerivation,
             ACE: KeyAeadInPlace + KeySecretBytes,
             AKDF: JoseKDF<AKE, AKW>,
-            AKE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue,
+            AKE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue + Clone,
             AKW: KeyWrap + FromKeyDerivation,
             SK: KeySigVerify + FromJwkValue,
         {
@@ -955,8 +955,9 @@ mod tests {
             );
 
             let msg =
-                _verify_anoncrypt::<ACE, AKDF, AKE, AKW>(&msg, to_keys.clone(), enc_alg_anon_jwe);
-            let msg = _verify_authcrypt::<CE, KDF, KE, KW>(&msg, to_keys, from_key);
+                _verify_anoncrypt::<ACE, AKDF, AKE, AKW>(&msg, to_keys.clone(), enc_alg_anon_jwe)
+                    .await;
+            let msg = _verify_authcrypt::<CE, KDF, KE, KW>(&msg, to_keys, from_key).await;
             let msg = _verify_signed::<SK>(&msg, sign_by_key, sign_alg);
             _verify_plaintext(&msg, PLAINTEXT_MSG_SIMPLE);
         }
@@ -1050,7 +1051,7 @@ mod tests {
         ) where
             CE: KeyAeadInPlace + KeySecretBytes,
             KDF: JoseKDF<KE, KW>,
-            KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue,
+            KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue + Clone,
             KW: KeyWrap + FromKeyDerivation,
             SK: KeySigVerify + FromJwkValue,
         {
@@ -1084,7 +1085,7 @@ mod tests {
                 }
             );
 
-            let msg = _verify_authcrypt::<CE, KDF, KE, KW>(&msg, to_keys, from_key);
+            let msg = _verify_authcrypt::<CE, KDF, KE, KW>(&msg, to_keys, from_key).await;
             let msg = _verify_signed::<SK>(&msg, sign_by_key, sign_alg);
             _verify_plaintext(&msg, PLAINTEXT_MSG_SIMPLE);
         }
@@ -1307,7 +1308,7 @@ mod tests {
         ) where
             CE: KeyAeadInPlace + KeySecretBytes,
             KDF: JoseKDF<KE, KW>,
-            KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue,
+            KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue + Clone,
             KW: KeyWrap + FromKeyDerivation,
         {
             let did_resolver =
@@ -1341,7 +1342,7 @@ mod tests {
                 }
             );
 
-            let msg = _verify_anoncrypt::<CE, KDF, KE, KW>(&msg, to_keys, enc_alg_jwe);
+            let msg = _verify_anoncrypt::<CE, KDF, KE, KW>(&msg, to_keys, enc_alg_jwe).await;
             _verify_plaintext(&msg, PLAINTEXT_MSG_SIMPLE);
         }
     }
@@ -1473,7 +1474,7 @@ mod tests {
         ) where
             CE: KeyAeadInPlace + KeySecretBytes,
             KDF: JoseKDF<KE, KW>,
-            KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue,
+            KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue + Clone,
             KW: KeyWrap + FromKeyDerivation,
             SK: KeySigVerify + FromJwkValue,
         {
@@ -1508,7 +1509,7 @@ mod tests {
                 }
             );
 
-            let msg = _verify_anoncrypt::<CE, KDF, KE, KW>(&msg, to_keys, enc_alg_jwe);
+            let msg = _verify_anoncrypt::<CE, KDF, KE, KW>(&msg, to_keys, enc_alg_jwe).await;
             let msg = _verify_signed::<SK>(&msg, sign_by_key, sign_alg);
             _verify_plaintext(&msg, PLAINTEXT_MSG_SIMPLE);
         }
@@ -2828,7 +2829,7 @@ mod tests {
         assert_eq!(unpack_metadata.from_prior.as_ref(), Some(&*FROM_PRIOR_FULL));
     }
 
-    fn _verify_authcrypt<CE, KDF, KE, KW>(
+    async fn _verify_authcrypt<CE, KDF, KE, KW>(
         msg: &str,
         to_keys: Vec<&Secret>,
         from_key: &VerificationMethod,
@@ -2836,7 +2837,7 @@ mod tests {
     where
         CE: KeyAeadInPlace + KeySecretBytes,
         KDF: JoseKDF<KE, KW>,
-        KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue,
+        KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue + Clone,
         KW: KeyWrap + FromKeyDerivation,
     {
         let mut buf = vec![];
@@ -2880,18 +2881,30 @@ mod tests {
                 _ => panic!("Unexpected verification method"),
             };
 
-            let derive_func = |ephem_key: &KE,
-                               sender_key: Option<&KE>,
+            let derive_func = |ephem_key: KE,
+                               sender_key: Option<KE>,
                                recip_kid: &str,
-                               alg: &[u8],
-                               apu: &[u8],
-                               apv: &[u8],
-                               cc_tag: &[u8]| {
-                KDF::derive_key(ephem_key, sender_key, &to_key, alg, apu, apv, cc_tag, true)
+                               alg: Vec<u8>,
+                               apu: Vec<u8>,
+                               apv: Vec<u8>,
+                               cc_tag: Vec<u8>| {
+                async move {
+                    KDF::derive_key(
+                        &ephem_key,
+                        sender_key.as_ref(),
+                        &to_key,
+                        &alg,
+                        &apu,
+                        &apv,
+                        &cc_tag,
+                        true,
+                    )
+                }
             };
 
             let msg = msg
-                .decrypt::<CE, KDF, KE, KW>(Some((from_kid, &from_key)), (to_kid, derive_func))
+                .decrypt::<CE, KDF, KE, KW, _>(Some((from_kid, &from_key)), (to_kid, derive_func))
+                .await
                 .expect("Unable decrypt msg");
 
             common_msg = if let Some(ref res) = common_msg {
@@ -2906,7 +2919,7 @@ mod tests {
         String::from_utf8(msg).expect("Unable from_utf8")
     }
 
-    fn _verify_anoncrypt<CE, KDF, KE, KW>(
+    async fn _verify_anoncrypt<CE, KDF, KE, KW>(
         msg: &str,
         to_keys: Vec<&Secret>,
         enc_alg: jwe::EncAlgorithm,
@@ -2914,7 +2927,7 @@ mod tests {
     where
         CE: KeyAeadInPlace + KeySecretBytes,
         KDF: JoseKDF<KE, KW>,
-        KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue,
+        KE: KeyExchange + KeyGen + ToJwkValue + FromJwkValue + Clone,
         KW: KeyWrap + FromKeyDerivation,
     {
         let mut buf = vec![];
@@ -2950,18 +2963,30 @@ mod tests {
                 _ => panic!("Unexpected verification method"),
             };
 
-            let derive_func = |ephem_key: &KE,
-                               sender_key: Option<&KE>,
+            let derive_func = |ephem_key: KE,
+                               sender_key: Option<KE>,
                                recip_kid: &str,
-                               alg: &[u8],
-                               apu: &[u8],
-                               apv: &[u8],
-                               cc_tag: &[u8]| {
-                KDF::derive_key(ephem_key, sender_key, &to_key, alg, apu, apv, cc_tag, true)
+                               alg: Vec<u8>,
+                               apu: Vec<u8>,
+                               apv: Vec<u8>,
+                               cc_tag: Vec<u8>| {
+                async move {
+                    KDF::derive_key(
+                        &ephem_key,
+                        sender_key.as_ref(),
+                        &to_key,
+                        &alg,
+                        &apu,
+                        &apv,
+                        &cc_tag,
+                        true,
+                    )
+                }
             };
 
             let msg = msg
-                .decrypt::<CE, KDF, KE, KW>(None, (to_kid, derive_func))
+                .decrypt::<CE, KDF, KE, KW, _>(None, (to_kid, derive_func))
+                .await
                 .expect("Unable decrypt msg");
 
             common_msg = if let Some(ref res) = common_msg {

--- a/src/message/pack_encrypted/mod.rs
+++ b/src/message/pack_encrypted/mod.rs
@@ -2880,8 +2880,18 @@ mod tests {
                 _ => panic!("Unexpected verification method"),
             };
 
+            let derive_func = |ephem_key: &KE,
+                               sender_key: Option<&KE>,
+                               recip_kid: &str,
+                               alg: &[u8],
+                               apu: &[u8],
+                               apv: &[u8],
+                               cc_tag: &[u8]| {
+                KDF::derive_key(ephem_key, sender_key, &to_key, alg, apu, apv, cc_tag, true)
+            };
+
             let msg = msg
-                .decrypt::<CE, KDF, KE, KW>(Some((from_kid, &from_key)), (to_kid, &to_key))
+                .decrypt::<CE, KDF, KE, KW>(Some((from_kid, &from_key)), (to_kid, derive_func))
                 .expect("Unable decrypt msg");
 
             common_msg = if let Some(ref res) = common_msg {
@@ -2940,8 +2950,18 @@ mod tests {
                 _ => panic!("Unexpected verification method"),
             };
 
+            let derive_func = |ephem_key: &KE,
+                               sender_key: Option<&KE>,
+                               recip_kid: &str,
+                               alg: &[u8],
+                               apu: &[u8],
+                               apv: &[u8],
+                               cc_tag: &[u8]| {
+                KDF::derive_key(ephem_key, sender_key, &to_key, alg, apu, apv, cc_tag, true)
+            };
+
             let msg = msg
-                .decrypt::<CE, KDF, KE, KW>(None, (to_kid, &to_key))
+                .decrypt::<CE, KDF, KE, KW>(None, (to_kid, derive_func))
                 .expect("Unable decrypt msg");
 
             common_msg = if let Some(ref res) = common_msg {

--- a/src/message/pack_plaintext.rs
+++ b/src/message/pack_plaintext.rs
@@ -74,7 +74,7 @@ mod tests {
     use crate::{
         did::resolvers::ExampleDIDResolver,
         error::ErrorKind,
-        secrets::resolvers::ExampleSecretsResolver,
+        secrets::resolvers::ExampleKMS,
         test_vectors::{
             ALICE_DID_DOC, BOB_DID_DOC, BOB_SECRETS, CHARLIE_DID_DOC,
             CHARLIE_SECRET_AUTH_KEY_ED25519, FROM_PRIOR_FULL, MESSAGE_ATTACHMENT_BASE64,
@@ -131,7 +131,7 @@ mod tests {
             BOB_DID_DOC.clone(),
             CHARLIE_DID_DOC.clone(),
         ]);
-        let bob_secrets_resolver = ExampleSecretsResolver::new(BOB_SECRETS.clone());
+        let bob_kms = ExampleKMS::new(BOB_SECRETS.clone());
 
         let packed_msg = MESSAGE_FROM_PRIOR_FULL
             .pack_plaintext(&did_resolver)
@@ -141,7 +141,7 @@ mod tests {
         let (unpacked_msg, unpack_metadata) = Message::unpack(
             &packed_msg,
             &did_resolver,
-            &bob_secrets_resolver,
+            &bob_kms,
             &UnpackOptions::default(),
         )
         .await

--- a/src/message/unpack/anoncrypt.rs
+++ b/src/message/unpack/anoncrypt.rs
@@ -18,7 +18,6 @@ use askar_crypto::{
     },
     kdf::ecdh_es::EcdhEs,
 };
-use tokio::runtime::Handle;
 
 pub(crate) async fn _try_unpack_anoncrypt<'sr>(
     msg: &str,
@@ -101,19 +100,19 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         EcdhEs<'_, X25519KeyPair>,
                         X25519KeyPair,
                         AesKey<A256Kw>,
-                    >(None, (to_kid, |ephem_key: &X25519KeyPair,
-                                      send_key: Option<&X25519KeyPair>,
-                                      recip_kid: &str,
-                                      alg: &[u8],
-                                      apu: &[u8],
-                                      apv: &[u8],
-                                      cc_tag: &[u8]| {
-                    Handle::current().block_on(
+                        _
+                    >(None, (to_kid,
+                             |ephem_key: X25519KeyPair,
+                              send_key: Option<&X25519KeyPair>,
+                              recip_kid: &str,
+                              alg: &[u8],
+                              apu: &[u8],
+                              apv: &[u8],
+                              _cc_tag: Vec<u8>| {
                         secrets_resolver.derive_aes_key_from_x25519_using_edches(
                             ephem_key, recip_kid, alg, apu, apv, true,
-                        ),
-                    )
-                }))?
+                        )
+                })).await?
             }
             (KnownKeyPair::X25519(ref to_key), jwe::EncAlgorithm::Xc20P) => {
                 metadata.enc_alg_anon = Some(AnonCryptAlg::Xc20pEcdhEsA256kw);
@@ -123,19 +122,18 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         EcdhEs<'_, X25519KeyPair>,
                         X25519KeyPair,
                         AesKey<A256Kw>,
-                    >(None, (to_kid, |ephem_key: &X25519KeyPair,
+                        _
+                    >(None, (to_kid, |ephem_key: X25519KeyPair,
                                       send_key: Option<&X25519KeyPair>,
                                       recip_kid: &str,
                                       alg: &[u8],
                                       apu: &[u8],
                                       apv: &[u8],
-                                      cc_tag: &[u8]| {
-                    Handle::current().block_on(
+                                      cc_tag: Vec<u8>| {
                         secrets_resolver.derive_aes_key_from_x25519_using_edches(
                             ephem_key, recip_kid, alg, apu, apv, true,
-                        ),
-                    )
-                }))?
+                        )
+                })).await?
             }
             (KnownKeyPair::X25519(ref to_key), jwe::EncAlgorithm::A256Gcm) => {
                 metadata.enc_alg_anon = Some(AnonCryptAlg::A256gcmEcdhEsA256kw);
@@ -145,19 +143,18 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         EcdhEs<'_, X25519KeyPair>,
                         X25519KeyPair,
                         AesKey<A256Kw>,
-                    >(None, (to_kid, |ephem_key: &X25519KeyPair,
+                        _
+                    >(None, (to_kid, |ephem_key: X25519KeyPair,
                                       send_key: Option<&X25519KeyPair>,
                                       recip_kid: &str,
                                       alg: &[u8],
                                       apu: &[u8],
                                       apv: &[u8],
-                                      cc_tag: &[u8]| {
-                    Handle::current().block_on(
+                                      cc_tag: Vec<u8>| {
                         secrets_resolver.derive_aes_key_from_x25519_using_edches(
                             ephem_key, recip_kid, alg, apu, apv, true,
-                        ),
-                    )
-                }))?
+                        )
+                })).await?
             }
             (KnownKeyPair::P256(ref to_key), jwe::EncAlgorithm::A256cbcHs512) => {
                 metadata.enc_alg_anon = Some(AnonCryptAlg::A256cbcHs512EcdhEsA256kw);
@@ -167,19 +164,18 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         EcdhEs<'_, P256KeyPair>,
                         P256KeyPair,
                         AesKey<A256Kw>,
-                    >(None, (to_kid, |ephem_key: &P256KeyPair,
+                        _
+                    >(None, (to_kid, |ephem_key: P256KeyPair,
                                       send_key: Option<&P256KeyPair>,
                                       recip_kid: &str,
                                       alg: &[u8],
                                       apu: &[u8],
                                       apv: &[u8],
-                                      cc_tag: &[u8]| {
-                    Handle::current().block_on(
+                                      _cc_tag: Vec<u8>| {
                         secrets_resolver.derive_aes_key_from_p256_using_edches(
                             ephem_key, recip_kid, alg, apu, apv, true,
-                        ),
-                    )
-                }))?
+                        )
+                })).await?
             }
             (KnownKeyPair::P256(ref to_key), jwe::EncAlgorithm::Xc20P) => {
                 metadata.enc_alg_anon = Some(AnonCryptAlg::Xc20pEcdhEsA256kw);
@@ -189,19 +185,18 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         EcdhEs<'_, P256KeyPair>,
                         P256KeyPair,
                         AesKey<A256Kw>,
-                    >(None, (to_kid, |ephem_key: &P256KeyPair,
+                        _
+                    >(None, (to_kid, |ephem_key: P256KeyPair,
                                       send_key: Option<&P256KeyPair>,
                                       recip_kid: &str,
                                       alg: &[u8],
                                       apu: &[u8],
                                       apv: &[u8],
-                                      cc_tag: &[u8]| {
-                    Handle::current().block_on(
+                                      _cc_tag: Vec<u8>| {
                         secrets_resolver.derive_aes_key_from_p256_using_edches(
                             ephem_key, recip_kid, alg, apu, apv, true,
-                        ),
-                    )
-                }))?
+                        )
+                })).await?
             }
             (KnownKeyPair::P256(ref to_key), jwe::EncAlgorithm::A256Gcm) => {
                 metadata.enc_alg_anon = Some(AnonCryptAlg::A256gcmEcdhEsA256kw);
@@ -211,19 +206,18 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         EcdhEs<'_, P256KeyPair>,
                         P256KeyPair,
                         AesKey<A256Kw>,
-                    >(None, (to_kid, |ephem_key: &P256KeyPair,
+                        _
+                    >(None, (to_kid, |ephem_key: P256KeyPair,
                                       send_key: Option<&P256KeyPair>,
                                       recip_kid: &str,
                                       alg: &[u8],
                                       apu: &[u8],
                                       apv: &[u8],
-                                      cc_tag: &[u8]| {
-                    Handle::current().block_on(
+                                      _cc_tag: Vec<u8>| {
                         secrets_resolver.derive_aes_key_from_p256_using_edches(
                             ephem_key, recip_kid, alg, apu, apv, true,
-                        ),
-                    )
-                }))?
+                        )
+                })).await?
             }
             _ => Err(err_msg(
                 ErrorKind::Unsupported,

--- a/src/message/unpack/anoncrypt.rs
+++ b/src/message/unpack/anoncrypt.rs
@@ -1,13 +1,3 @@
-use askar_crypto::{
-    alg::{
-        aes::{A256CbcHs512, A256Gcm, A256Kw, AesKey},
-        chacha20::{Chacha20Key, XC20P},
-        p256::P256KeyPair,
-        x25519::X25519KeyPair,
-    },
-    kdf::ecdh_es::EcdhEs,
-};
-
 use crate::{
     algorithms::AnonCryptAlg,
     error::{err_msg, ErrorKind, Result, ResultExt},
@@ -19,6 +9,16 @@ use crate::{
     },
     UnpackMetadata, UnpackOptions,
 };
+use askar_crypto::{
+    alg::{
+        aes::{A256CbcHs512, A256Gcm, A256Kw, AesKey},
+        chacha20::{Chacha20Key, XC20P},
+        p256::P256KeyPair,
+        x25519::X25519KeyPair,
+    },
+    kdf::ecdh_es::EcdhEs,
+};
+use tokio::runtime::Handle;
 
 pub(crate) async fn _try_unpack_anoncrypt<'sr>(
     msg: &str,
@@ -101,7 +101,19 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         EcdhEs<'_, X25519KeyPair>,
                         X25519KeyPair,
                         AesKey<A256Kw>,
-                    >(None, (to_kid, to_key))?
+                    >(None, (to_kid, |ephem_key: &X25519KeyPair,
+                                      send_key: Option<&X25519KeyPair>,
+                                      recip_kid: &str,
+                                      alg: &[u8],
+                                      apu: &[u8],
+                                      apv: &[u8],
+                                      cc_tag: &[u8]| {
+                    Handle::current().block_on(
+                        secrets_resolver.derive_aes_key_from_x25519_using_edches(
+                            ephem_key, recip_kid, alg, apu, apv, true,
+                        ),
+                    )
+                }))?
             }
             (KnownKeyPair::X25519(ref to_key), jwe::EncAlgorithm::Xc20P) => {
                 metadata.enc_alg_anon = Some(AnonCryptAlg::Xc20pEcdhEsA256kw);
@@ -111,7 +123,19 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         EcdhEs<'_, X25519KeyPair>,
                         X25519KeyPair,
                         AesKey<A256Kw>,
-                    >(None, (to_kid, to_key))?
+                    >(None, (to_kid, |ephem_key: &X25519KeyPair,
+                                      send_key: Option<&X25519KeyPair>,
+                                      recip_kid: &str,
+                                      alg: &[u8],
+                                      apu: &[u8],
+                                      apv: &[u8],
+                                      cc_tag: &[u8]| {
+                    Handle::current().block_on(
+                        secrets_resolver.derive_aes_key_from_x25519_using_edches(
+                            ephem_key, recip_kid, alg, apu, apv, true,
+                        ),
+                    )
+                }))?
             }
             (KnownKeyPair::X25519(ref to_key), jwe::EncAlgorithm::A256Gcm) => {
                 metadata.enc_alg_anon = Some(AnonCryptAlg::A256gcmEcdhEsA256kw);
@@ -121,7 +145,19 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         EcdhEs<'_, X25519KeyPair>,
                         X25519KeyPair,
                         AesKey<A256Kw>,
-                    >(None, (to_kid, to_key))?
+                    >(None, (to_kid, |ephem_key: &X25519KeyPair,
+                                      send_key: Option<&X25519KeyPair>,
+                                      recip_kid: &str,
+                                      alg: &[u8],
+                                      apu: &[u8],
+                                      apv: &[u8],
+                                      cc_tag: &[u8]| {
+                    Handle::current().block_on(
+                        secrets_resolver.derive_aes_key_from_x25519_using_edches(
+                            ephem_key, recip_kid, alg, apu, apv, true,
+                        ),
+                    )
+                }))?
             }
             (KnownKeyPair::P256(ref to_key), jwe::EncAlgorithm::A256cbcHs512) => {
                 metadata.enc_alg_anon = Some(AnonCryptAlg::A256cbcHs512EcdhEsA256kw);
@@ -131,7 +167,19 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         EcdhEs<'_, P256KeyPair>,
                         P256KeyPair,
                         AesKey<A256Kw>,
-                    >(None, (to_kid, to_key))?
+                    >(None, (to_kid, |ephem_key: &P256KeyPair,
+                                      send_key: Option<&P256KeyPair>,
+                                      recip_kid: &str,
+                                      alg: &[u8],
+                                      apu: &[u8],
+                                      apv: &[u8],
+                                      cc_tag: &[u8]| {
+                    Handle::current().block_on(
+                        secrets_resolver.derive_aes_key_from_p256_using_edches(
+                            ephem_key, recip_kid, alg, apu, apv, true,
+                        ),
+                    )
+                }))?
             }
             (KnownKeyPair::P256(ref to_key), jwe::EncAlgorithm::Xc20P) => {
                 metadata.enc_alg_anon = Some(AnonCryptAlg::Xc20pEcdhEsA256kw);
@@ -141,7 +189,19 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         EcdhEs<'_, P256KeyPair>,
                         P256KeyPair,
                         AesKey<A256Kw>,
-                    >(None, (to_kid, to_key))?
+                    >(None, (to_kid, |ephem_key: &P256KeyPair,
+                                      send_key: Option<&P256KeyPair>,
+                                      recip_kid: &str,
+                                      alg: &[u8],
+                                      apu: &[u8],
+                                      apv: &[u8],
+                                      cc_tag: &[u8]| {
+                    Handle::current().block_on(
+                        secrets_resolver.derive_aes_key_from_p256_using_edches(
+                            ephem_key, recip_kid, alg, apu, apv, true,
+                        ),
+                    )
+                }))?
             }
             (KnownKeyPair::P256(ref to_key), jwe::EncAlgorithm::A256Gcm) => {
                 metadata.enc_alg_anon = Some(AnonCryptAlg::A256gcmEcdhEsA256kw);
@@ -151,7 +211,19 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         EcdhEs<'_, P256KeyPair>,
                         P256KeyPair,
                         AesKey<A256Kw>,
-                    >(None, (to_kid, to_key))?
+                    >(None, (to_kid, |ephem_key: &P256KeyPair,
+                                      send_key: Option<&P256KeyPair>,
+                                      recip_kid: &str,
+                                      alg: &[u8],
+                                      apu: &[u8],
+                                      apv: &[u8],
+                                      cc_tag: &[u8]| {
+                    Handle::current().block_on(
+                        secrets_resolver.derive_aes_key_from_p256_using_edches(
+                            ephem_key, recip_kid, alg, apu, apv, true,
+                        ),
+                    )
+                }))?
             }
             _ => Err(err_msg(
                 ErrorKind::Unsupported,

--- a/src/message/unpack/anoncrypt.rs
+++ b/src/message/unpack/anoncrypt.rs
@@ -103,11 +103,11 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         _
                     >(None, (to_kid,
                              |ephem_key: X25519KeyPair,
-                              send_key: Option<&X25519KeyPair>,
+                              send_key: Option<X25519KeyPair>,
                               recip_kid: &str,
-                              alg: &[u8],
-                              apu: &[u8],
-                              apv: &[u8],
+                              alg: Vec<u8>,
+                              apu: Vec<u8>,
+                              apv: Vec<u8>,
                               _cc_tag: Vec<u8>| {
                         secrets_resolver.derive_aes_key_from_x25519_using_edches(
                             ephem_key, recip_kid, alg, apu, apv, true,
@@ -124,11 +124,11 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         AesKey<A256Kw>,
                         _
                     >(None, (to_kid, |ephem_key: X25519KeyPair,
-                                      send_key: Option<&X25519KeyPair>,
+                                      send_key: Option<X25519KeyPair>,
                                       recip_kid: &str,
-                                      alg: &[u8],
-                                      apu: &[u8],
-                                      apv: &[u8],
+                                      alg: Vec<u8>,
+                                      apu: Vec<u8>,
+                                      apv: Vec<u8>,
                                       cc_tag: Vec<u8>| {
                         secrets_resolver.derive_aes_key_from_x25519_using_edches(
                             ephem_key, recip_kid, alg, apu, apv, true,
@@ -145,11 +145,11 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         AesKey<A256Kw>,
                         _
                     >(None, (to_kid, |ephem_key: X25519KeyPair,
-                                      send_key: Option<&X25519KeyPair>,
+                                      send_key: Option<X25519KeyPair>,
                                       recip_kid: &str,
-                                      alg: &[u8],
-                                      apu: &[u8],
-                                      apv: &[u8],
+                                      alg: Vec<u8>,
+                                      apu: Vec<u8>,
+                                      apv: Vec<u8>,
                                       cc_tag: Vec<u8>| {
                         secrets_resolver.derive_aes_key_from_x25519_using_edches(
                             ephem_key, recip_kid, alg, apu, apv, true,
@@ -166,11 +166,11 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         AesKey<A256Kw>,
                         _
                     >(None, (to_kid, |ephem_key: P256KeyPair,
-                                      send_key: Option<&P256KeyPair>,
+                                      send_key: Option<P256KeyPair>,
                                       recip_kid: &str,
-                                      alg: &[u8],
-                                      apu: &[u8],
-                                      apv: &[u8],
+                                      alg: Vec<u8>,
+                                      apu: Vec<u8>,
+                                      apv: Vec<u8>,
                                       _cc_tag: Vec<u8>| {
                         secrets_resolver.derive_aes_key_from_p256_using_edches(
                             ephem_key, recip_kid, alg, apu, apv, true,
@@ -187,11 +187,11 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         AesKey<A256Kw>,
                         _
                     >(None, (to_kid, |ephem_key: P256KeyPair,
-                                      send_key: Option<&P256KeyPair>,
+                                      send_key: Option<P256KeyPair>,
                                       recip_kid: &str,
-                                      alg: &[u8],
-                                      apu: &[u8],
-                                      apv: &[u8],
+                                      alg: Vec<u8>,
+                                      apu: Vec<u8>,
+                                      apv: Vec<u8>,
                                       _cc_tag: Vec<u8>| {
                         secrets_resolver.derive_aes_key_from_p256_using_edches(
                             ephem_key, recip_kid, alg, apu, apv, true,
@@ -208,11 +208,11 @@ pub(crate) async fn _try_unpack_anoncrypt<'sr>(
                         AesKey<A256Kw>,
                         _
                     >(None, (to_kid, |ephem_key: P256KeyPair,
-                                      send_key: Option<&P256KeyPair>,
+                                      send_key: Option<P256KeyPair>,
                                       recip_kid: &str,
-                                      alg: &[u8],
-                                      apu: &[u8],
-                                      apv: &[u8],
+                                      alg: Vec<u8>,
+                                      apu: Vec<u8>,
+                                      apv: Vec<u8>,
                                       _cc_tag: Vec<u8>| {
                         secrets_resolver.derive_aes_key_from_p256_using_edches(
                             ephem_key, recip_kid, alg, apu, apv, true,

--- a/src/message/unpack/authcrypt.rs
+++ b/src/message/unpack/authcrypt.rs
@@ -157,11 +157,11 @@ pub(crate) async fn _try_unpack_authcrypt<'dr, 'sr>(
                     AesKey<A256Kw>,
                     _
                 >(Some((from_kid, from_key)), (to_kid, |ephem_key: X25519KeyPair,
-                                                        send_key: Option<&X25519KeyPair>,
+                                                        send_key: Option<X25519KeyPair>,
                                                         recip_kid: &str,
-                                                        alg: &[u8],
-                                                        apu: &[u8],
-                                                        apv: &[u8],
+                                                        alg: Vec<u8>,
+                                                        apu: Vec<u8>,
+                                                        apv: Vec<u8>,
                                                         cc_tag: Vec<u8>| {
                     async move {
                         let send_key = send_key.ok_or_else(|| {
@@ -169,7 +169,7 @@ pub(crate) async fn _try_unpack_authcrypt<'dr, 'sr>(
                         })?;
 
                         secrets_resolver.derive_aes_key_from_x25519_using_edch1pu_receive(
-                            &ephem_key, send_key, recip_kid, alg, apu, apv, &cc_tag, true,
+                            ephem_key, send_key, recip_kid, alg, apu, apv, cc_tag, true,
                         ).await
                     }
                 })).await?
@@ -188,22 +188,20 @@ pub(crate) async fn _try_unpack_authcrypt<'dr, 'sr>(
                     AesKey<A256Kw>,
                     _
                 >(Some((from_kid, from_key)), (to_kid, |ephem_key: P256KeyPair,
-                                                        send_key: Option<&P256KeyPair>,
+                                                        send_key: Option<P256KeyPair>,
                                                         recip_kid: &str,
-                                                        alg: &[u8],
-                                                        apu: &[u8],
-                                                        apv: &[u8],
+                                                        alg: Vec<u8>,
+                                                        apu: Vec<u8>,
+                                                        apv: Vec<u8>,
                                                         cc_tag: Vec<u8>| {
                     async move {
                         let send_key = send_key.ok_or_else(|| {
                             err_msg(ErrorKind::InvalidState, "No sender key for ecdh-1pu")
                         })?;
 
-                        Handle::current().block_on(
                             secrets_resolver.derive_aes_key_from_p256_using_edch1pu_receive(
-                                &ephem_key, send_key, recip_kid, alg, apu, apv, &cc_tag, true,
-                            ),
-                        )
+                                ephem_key, send_key, recip_kid, alg, apu, apv, cc_tag, true,
+                            ).await
                     }
                 })).await?
             }

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -2,6 +2,9 @@
 
 pub mod resolvers;
 
+use askar_crypto::alg::aes::{A256Kw, AesKey};
+use askar_crypto::alg::p256::P256KeyPair;
+use askar_crypto::alg::x25519::X25519KeyPair;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -35,6 +38,30 @@ pub trait SecretsResolver: Sync {
     /// # Returns
     /// possible empty list of all secrets that have one of the given IDs.
     async fn find_secrets<'a>(&self, secret_ids: &'a [&'a str]) -> Result<Vec<&'a str>>;
+
+    async fn derive_aes_key_from_x25519_using_edch1pu(
+        &self,
+        ephem_key: &X25519KeyPair,
+        send_kid: &str,
+        recip_key: &X25519KeyPair,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        cc_tag: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>>;
+
+    async fn derive_aes_key_from_p256_using_edch1pu(
+        &self,
+        ephem_key: &P256KeyPair,
+        send_kid: &str,
+        recip_key: &P256KeyPair,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        cc_tag: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>>;
 }
 
 /// Interface for secrets resolver.
@@ -64,6 +91,30 @@ pub trait SecretsResolver {
     /// # Returns
     /// possible empty list of all secrets that have one of the given IDs.
     async fn find_secrets<'a>(&self, secret_ids: &'a [&'a str]) -> Result<Vec<&'a str>>;
+
+    async fn derive_aes_key_from_x25519_using_edch1pu(
+        &self,
+        ephem_key: &X25519KeyPair,
+        send_kid: &str,
+        recip_key: &X25519KeyPair,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        cc_tag: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>>;
+
+    async fn derive_aes_key_from_p256_using_edch1pu(
+        &self,
+        ephem_key: &P256KeyPair,
+        send_kid: &str,
+        recip_key: &P256KeyPair,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        cc_tag: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>>;
 }
 
 /// Represents secret.

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -9,41 +9,58 @@ use askar_crypto::alg::KeyAlg;
 use askar_crypto::buffer::SecretBytes;
 use askar_crypto::sign::SignatureType;
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use crate::error::Result;
 
-/// Interface for secrets resolver.
+pub enum KeyOrKid {
+    Kid(String),
+    X25519KeyPair(X25519KeyPair),
+    P256KeyPair(P256KeyPair),
+}
+
+/// Interface for KeyManagementService.
 /// Resolves secrets such as private keys to be used for signing and encryption.
 #[cfg(feature = "uniffi")]
 #[async_trait]
-pub trait SecretsResolver: Sync {
+pub trait KeyManagementService: Sync {
     /// Finds secret (usually private key) identified by the given key ID.
     ///
     /// # Parameters
     /// - `secret_id` the ID (in form of DID URL) identifying a secret
     ///
     /// # Returns
-    /// A secret (usually private key) or None of there is no secret for the given ID
+    /// A key algorithm of the secret or None of there is no secret for the given ID
     ///
     /// # Errors
     /// - IOError
     /// - InvalidState
-    // async fn get_secret(&self, secret_id: &str) -> Result<Option<Secret>>;
-
     async fn get_key_alg(&self, secret_id: &str) -> Result<KeyAlg>;
 
     /// Find all secrets that have one of the given IDs.
-    /// Return secrets only for key IDs for which a secret is present.
+    /// Return ids of secrets only for key IDs for which a secret is present.
     ///
     /// # Parameters
-    /// - `secret_ids` the IDs find secrets for
+    /// - `secret_ids` the IDs to check for existence
     ///
     /// # Returns
-    /// possible empty list of all secrets that have one of the given IDs.
+    /// possible empty list of all secrets IDs that have one of the given IDs.
     async fn find_secrets<'a>(&self, secret_ids: &'a [&'a str]) -> Result<Vec<&'a str>>;
 
+    /// Create a signature of the requested type and return an allocated
+    /// buffer.
+    ///
+    /// # Parameters
+    /// - `secret_id` the ID (in form of DID URL) identifying a secret
+    /// - `message` bytes to be signed
+    /// - `sig_type`: signature type to be used.
+    ///
+    /// # Returns
+    /// Signature
+    ///
+    /// # Errors
+    /// - IOError
+    /// - IvalidState
+    /// - Unsupported
     async fn create_signature(
         &self,
         secret_id: &str,
@@ -51,11 +68,22 @@ pub trait SecretsResolver: Sync {
         sig_type: Option<SignatureType>,
     ) -> Result<SecretBytes>;
 
-    async fn derive_aes_key_from_x25519_using_edch1pu(
+    /// ECDH-1PU derivation of key
+    ///
+    /// # Parameters
+    /// - `ephem_key` Ephemeral key (cannot be kid)
+    /// - `send_key` Sender key (or kid to be resolved by KMS)
+    /// - `recip_key`: Recipient key (or kid to be resolved by KMS)
+    /// - `alg`: algorithm
+    /// - `apu`: Sender info
+    /// - `apv`: Receiver info
+    /// - `cc_tag`: tag
+    /// - `receive`: Whether derived key is used on receive or send side.
+    async fn derive_aes_key_using_ecdh_1pu(
         &self,
-        ephem_key: X25519KeyPair,
-        send_kid: String,
-        recip_key: X25519KeyPair,
+        ephem_key: KeyOrKid,
+        send_key: KeyOrKid,
+        recip_key: KeyOrKid,
         alg: Vec<u8>,
         apu: Vec<u8>,
         apv: Vec<u8>,
@@ -63,56 +91,19 @@ pub trait SecretsResolver: Sync {
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 
-    async fn derive_aes_key_from_p256_using_edch1pu(
+    /// ECDH-1PU derivation of key
+    ///
+    /// # Parameters
+    /// - `ephem_key` Ephemeral key (cannot be kid)
+    /// - `recip_key`: Recipient key (or kid to be resolved by KMS)
+    /// - `alg`: algorithm
+    /// - `apu`: Sender info
+    /// - `apv`: Receiver info
+    /// - `receive`: Whether derived key is used on receive or send side.
+    async fn derive_aes_key_using_ecdh_es(
         &self,
-        ephem_key: P256KeyPair,
-        send_kid: String,
-        recip_key: P256KeyPair,
-        alg: Vec<u8>,
-        apu: Vec<u8>,
-        apv: Vec<u8>,
-        cc_tag: Vec<u8>,
-        receive: bool,
-    ) -> Result<AesKey<A256Kw>>;
-
-    async fn derive_aes_key_from_x25519_using_edch1pu_receive(
-        &self,
-        ephem_key: X25519KeyPair,
-        send_key: X25519KeyPair,
-        recip_kid: &str,
-        alg: Vec<u8>,
-        apu: Vec<u8>,
-        apv: Vec<u8>,
-        cc_tag: Vec<u8>,
-        receive: bool,
-    ) -> Result<AesKey<A256Kw>>;
-
-    async fn derive_aes_key_from_p256_using_edch1pu_receive(
-        &self,
-        ephem_key: &P256KeyPair,
-        send_key: &P256KeyPair,
-        recip_kid: &str,
-        alg: Vec<u8>,
-        apu: Vec<u8>,
-        apv: Vec<u8>,
-        cc_tag: Vec<u8>,
-        receive: bool,
-    ) -> Result<AesKey<A256Kw>>;
-
-    async fn derive_aes_key_from_x25519_using_edches(
-        &self,
-        ephem_key: X25519KeyPair,
-        recip_kid: &str,
-        alg: Vec<u8>,
-        apu: Vec<u8>,
-        apv: Vec<u8>,
-        receive: bool,
-    ) -> Result<AesKey<A256Kw>>;
-
-    async fn derive_aes_key_from_p256_using_edches(
-        &self,
-        ephem_key: P256KeyPair,
-        recip_kid: &str,
+        ephem_key: KeyOrKid,
+        recip_key: KeyOrKid,
         alg: Vec<u8>,
         apu: Vec<u8>,
         apv: Vec<u8>,
@@ -124,32 +115,45 @@ pub trait SecretsResolver: Sync {
 /// Resolves secrets such as private keys to be used for signing and encryption.
 #[cfg(not(feature = "uniffi"))]
 #[async_trait(?Send)]
-pub trait SecretsResolver {
+pub trait KeyManagementService {
     /// Finds secret (usually private key) identified by the given key ID.
     ///
     /// # Parameters
     /// - `secret_id` the ID (in form of DID URL) identifying a secret
     ///
     /// # Returns
-    /// A secret (usually private key) or None of there is no secret for the given ID
+    /// A key algorithm of the secret or None of there is no secret for the given ID
     ///
     /// # Errors
     /// - IOError
     /// - InvalidState
-    // async fn get_secret(&self, secret_id: &str) -> Result<Option<Secret>>;
-
     async fn get_key_alg(&self, secret_id: &str) -> Result<KeyAlg>;
 
     /// Find all secrets that have one of the given IDs.
-    /// Return secrets only for key IDs for which a secret is present.
+    /// Return ids of secrets only for key IDs for which a secret is present.
     ///
     /// # Parameters
-    /// - `secret_ids` the IDs find secrets for
+    /// - `secret_ids` the IDs to check for existence
     ///
     /// # Returns
-    /// possible empty list of all secrets that have one of the given IDs.
+    /// possible empty list of all secrets IDs that have one of the given IDs.
     async fn find_secrets<'a>(&self, secret_ids: &'a [&'a str]) -> Result<Vec<&'a str>>;
 
+    /// Create a signature of the requested type and return an allocated
+    /// buffer.
+    ///
+    /// # Parameters
+    /// - `secret_id` the ID (in form of DID URL) identifying a secret
+    /// - `message` bytes to be signed
+    /// - `sig_type`: signature type to be used.
+    ///
+    /// # Returns
+    /// Signature
+    ///
+    /// # Errors
+    /// - IOError
+    /// - IvalidState
+    /// - Unsupported
     async fn create_signature(
         &self,
         secret_id: &str,
@@ -157,11 +161,22 @@ pub trait SecretsResolver {
         sig_type: Option<SignatureType>,
     ) -> Result<SecretBytes>;
 
-    async fn derive_aes_key_from_x25519_using_edch1pu(
+    /// ECDH-1PU derivation of key
+    ///
+    /// # Parameters
+    /// - `ephem_key` Ephemeral key (cannot be kid)
+    /// - `send_key` Sender key (or kid to be resolved by KMS)
+    /// - `recip_key`: Recipient key (or kid to be resolved by KMS)
+    /// - `alg`: algorithm
+    /// - `apu`: Sender info
+    /// - `apv`: Receiver info
+    /// - `cc_tag`: tag
+    /// - `receive`: Whether derived key is used on receive or send side.
+    async fn derive_aes_key_using_ecdh_1pu(
         &self,
-        ephem_key: X25519KeyPair,
-        send_kid: String,
-        recip_key: X25519KeyPair,
+        ephem_key: KeyOrKid,
+        send_key: KeyOrKid,
+        recip_key: KeyOrKid,
         alg: Vec<u8>,
         apu: Vec<u8>,
         apv: Vec<u8>,
@@ -169,100 +184,22 @@ pub trait SecretsResolver {
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 
-    async fn derive_aes_key_from_p256_using_edch1pu(
+    /// ECDH-1PU derivation of key
+    ///
+    /// # Parameters
+    /// - `ephem_key` Ephemeral key (cannot be kid)
+    /// - `recip_key`: Recipient key (or kid to be resolved by KMS)
+    /// - `alg`: algorithm
+    /// - `apu`: Sender info
+    /// - `apv`: Receiver info
+    /// - `receive`: Whether derived key is used on receive or send side.
+    async fn derive_aes_key_using_ecdh_es(
         &self,
-        ephem_key: P256KeyPair,
-        send_kid: String,
-        recip_key: P256KeyPair,
-        alg: Vec<u8>,
-        apu: Vec<u8>,
-        apv: Vec<u8>,
-        cc_tag: Vec<u8>,
-        receive: bool,
-    ) -> Result<AesKey<A256Kw>>;
-
-    async fn derive_aes_key_from_x25519_using_edch1pu_receive(
-        &self,
-        ephem_key: X25519KeyPair,
-        send_key: X25519KeyPair,
-        recip_kid: &str,
-        alg: Vec<u8>,
-        apu: Vec<u8>,
-        apv: Vec<u8>,
-        cc_tag: Vec<u8>,
-        receive: bool,
-    ) -> Result<AesKey<A256Kw>>;
-
-    async fn derive_aes_key_from_p256_using_edch1pu_receive(
-        &self,
-        ephem_key: P256KeyPair,
-        send_key: P256KeyPair,
-        recip_kid: &str,
-        alg: Vec<u8>,
-        apu: Vec<u8>,
-        apv: Vec<u8>,
-        cc_tag: Vec<u8>,
-        receive: bool,
-    ) -> Result<AesKey<A256Kw>>;
-
-    async fn derive_aes_key_from_x25519_using_edches(
-        &self,
-        ephem_key: X25519KeyPair,
-        recip_kid: &str,
+        ephem_key: KeyOrKid,
+        recip_key: KeyOrKid,
         alg: Vec<u8>,
         apu: Vec<u8>,
         apv: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
-
-    async fn derive_aes_key_from_p256_using_edches(
-        &self,
-        ephem_key: P256KeyPair,
-        recip_kid: &str,
-        alg: Vec<u8>,
-        apu: Vec<u8>,
-        apv: Vec<u8>,
-        receive: bool,
-    ) -> Result<AesKey<A256Kw>>;
-}
-
-/// Represents secret.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Secret {
-    /// A key ID identifying a secret (private key).
-    pub id: String,
-
-    /// Must have the same semantics as type ('type' field) of the corresponding method in DID Doc containing a public key.
-    #[serde(rename = "type")]
-    pub type_: SecretType,
-
-    /// Value of the secret (private key)
-    #[serde(flatten)]
-    pub secret_material: SecretMaterial,
-}
-
-/// Must have the same semantics as type ('type' field) of the corresponding method in DID Doc containing a public key.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub enum SecretType {
-    JsonWebKey2020,
-    X25519KeyAgreementKey2019,
-    X25519KeyAgreementKey2020,
-    Ed25519VerificationKey2018,
-    Ed25519VerificationKey2020,
-    EcdsaSecp256k1VerificationKey2019,
-    Other,
-}
-
-/// Represents secret crypto material.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum SecretMaterial {
-    #[serde(rename_all = "camelCase")]
-    JWK { private_key_jwk: Value },
-
-    #[serde(rename_all = "camelCase")]
-    Multibase { private_key_multibase: String },
-
-    #[serde(rename_all = "camelCase")]
-    Base58 { private_key_base58: String },
 }

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -89,7 +89,7 @@ pub trait SecretsResolver: Sync {
 
     async fn derive_aes_key_from_x25519_using_edches(
         &self,
-        ephem_key: &X25519KeyPair,
+        ephem_key: X25519KeyPair,
         recip_kid: &str,
         alg: &[u8],
         apu: &[u8],
@@ -99,7 +99,7 @@ pub trait SecretsResolver: Sync {
 
     async fn derive_aes_key_from_p256_using_edches(
         &self,
-        ephem_key: &P256KeyPair,
+        ephem_key: P256KeyPair,
         recip_kid: &str,
         alg: &[u8],
         apu: &[u8],
@@ -186,7 +186,7 @@ pub trait SecretsResolver {
 
     async fn derive_aes_key_from_x25519_using_edches(
         &self,
-        ephem_key: &X25519KeyPair,
+        ephem_key: X25519KeyPair,
         recip_kid: &str,
         alg: &[u8],
         apu: &[u8],
@@ -196,7 +196,7 @@ pub trait SecretsResolver {
 
     async fn derive_aes_key_from_p256_using_edches(
         &self,
-        ephem_key: &P256KeyPair,
+        ephem_key: P256KeyPair,
         recip_kid: &str,
         alg: &[u8],
         apu: &[u8],

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -62,6 +62,50 @@ pub trait SecretsResolver: Sync {
         cc_tag: &[u8],
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
+
+    async fn derive_aes_key_from_x25519_using_edch1pu_receive(
+        &self,
+        ephem_key: &X25519KeyPair,
+        send_key: &X25519KeyPair,
+        recip_kid: &str,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        cc_tag: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>>;
+
+    async fn derive_aes_key_from_p256_using_edch1pu_receive(
+        &self,
+        ephem_key: &P256KeyPair,
+        send_key: &P256KeyPair,
+        recip_kid: &str,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        cc_tag: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>>;
+
+    async fn derive_aes_key_from_x25519_using_edches(
+        &self,
+        ephem_key: &X25519KeyPair,
+        recip_kid: &str,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>>;
+
+    async fn derive_aes_key_from_p256_using_edches(
+        &self,
+        ephem_key: &P256KeyPair,
+        recip_kid: &str,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>>;
 }
 
 /// Interface for secrets resolver.
@@ -113,6 +157,50 @@ pub trait SecretsResolver {
         apu: &[u8],
         apv: &[u8],
         cc_tag: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>>;
+
+    async fn derive_aes_key_from_x25519_using_edch1pu_receive(
+        &self,
+        ephem_key: &X25519KeyPair,
+        send_key: &X25519KeyPair,
+        recip_kid: &str,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        cc_tag: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>>;
+
+    async fn derive_aes_key_from_p256_using_edch1pu_receive(
+        &self,
+        ephem_key: &P256KeyPair,
+        send_key: &P256KeyPair,
+        recip_kid: &str,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        cc_tag: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>>;
+
+    async fn derive_aes_key_from_x25519_using_edches(
+        &self,
+        ephem_key: &X25519KeyPair,
+        recip_kid: &str,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>>;
+
+    async fn derive_aes_key_from_p256_using_edches(
+        &self,
+        ephem_key: &P256KeyPair,
+        recip_kid: &str,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 }

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -41,37 +41,37 @@ pub trait SecretsResolver: Sync {
 
     async fn derive_aes_key_from_x25519_using_edch1pu(
         &self,
-        ephem_key: &X25519KeyPair,
-        send_kid: &str,
-        recip_key: &X25519KeyPair,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
-        cc_tag: &[u8],
+        ephem_key: X25519KeyPair,
+        send_kid: String,
+        recip_key: X25519KeyPair,
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
+        cc_tag: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 
     async fn derive_aes_key_from_p256_using_edch1pu(
         &self,
-        ephem_key: &P256KeyPair,
-        send_kid: &str,
-        recip_key: &P256KeyPair,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
-        cc_tag: &[u8],
+        ephem_key: P256KeyPair,
+        send_kid: String,
+        recip_key: P256KeyPair,
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
+        cc_tag: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 
     async fn derive_aes_key_from_x25519_using_edch1pu_receive(
         &self,
-        ephem_key: &X25519KeyPair,
-        send_key: &X25519KeyPair,
+        ephem_key: X25519KeyPair,
+        send_key: X25519KeyPair,
         recip_kid: &str,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
-        cc_tag: &[u8],
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
+        cc_tag: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 
@@ -80,10 +80,10 @@ pub trait SecretsResolver: Sync {
         ephem_key: &P256KeyPair,
         send_key: &P256KeyPair,
         recip_kid: &str,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
-        cc_tag: &[u8],
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
+        cc_tag: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 
@@ -91,9 +91,9 @@ pub trait SecretsResolver: Sync {
         &self,
         ephem_key: X25519KeyPair,
         recip_kid: &str,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 
@@ -101,9 +101,9 @@ pub trait SecretsResolver: Sync {
         &self,
         ephem_key: P256KeyPair,
         recip_kid: &str,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 }
@@ -138,49 +138,49 @@ pub trait SecretsResolver {
 
     async fn derive_aes_key_from_x25519_using_edch1pu(
         &self,
-        ephem_key: &X25519KeyPair,
-        send_kid: &str,
-        recip_key: &X25519KeyPair,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
-        cc_tag: &[u8],
+        ephem_key: X25519KeyPair,
+        send_kid: String,
+        recip_key: X25519KeyPair,
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
+        cc_tag: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 
     async fn derive_aes_key_from_p256_using_edch1pu(
         &self,
-        ephem_key: &P256KeyPair,
-        send_kid: &str,
-        recip_key: &P256KeyPair,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
-        cc_tag: &[u8],
+        ephem_key: P256KeyPair,
+        send_kid: String,
+        recip_key: P256KeyPair,
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
+        cc_tag: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 
     async fn derive_aes_key_from_x25519_using_edch1pu_receive(
         &self,
-        ephem_key: &X25519KeyPair,
-        send_key: &X25519KeyPair,
+        ephem_key: X25519KeyPair,
+        send_key: X25519KeyPair,
         recip_kid: &str,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
-        cc_tag: &[u8],
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
+        cc_tag: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 
     async fn derive_aes_key_from_p256_using_edch1pu_receive(
         &self,
-        ephem_key: &P256KeyPair,
-        send_key: &P256KeyPair,
+        ephem_key: P256KeyPair,
+        send_key: P256KeyPair,
         recip_kid: &str,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
-        cc_tag: &[u8],
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
+        cc_tag: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 
@@ -188,9 +188,9 @@ pub trait SecretsResolver {
         &self,
         ephem_key: X25519KeyPair,
         recip_kid: &str,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 
@@ -198,9 +198,9 @@ pub trait SecretsResolver {
         &self,
         ephem_key: P256KeyPair,
         recip_kid: &str,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>>;
 }

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -5,6 +5,9 @@ pub mod resolvers;
 use askar_crypto::alg::aes::{A256Kw, AesKey};
 use askar_crypto::alg::p256::P256KeyPair;
 use askar_crypto::alg::x25519::X25519KeyPair;
+use askar_crypto::alg::KeyAlg;
+use askar_crypto::buffer::SecretBytes;
+use askar_crypto::sign::SignatureType;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -27,7 +30,9 @@ pub trait SecretsResolver: Sync {
     /// # Errors
     /// - IOError
     /// - InvalidState
-    async fn get_secret(&self, secret_id: &str) -> Result<Option<Secret>>;
+    // async fn get_secret(&self, secret_id: &str) -> Result<Option<Secret>>;
+
+    async fn get_key_alg(&self, secret_id: &str) -> Result<KeyAlg>;
 
     /// Find all secrets that have one of the given IDs.
     /// Return secrets only for key IDs for which a secret is present.
@@ -38,6 +43,13 @@ pub trait SecretsResolver: Sync {
     /// # Returns
     /// possible empty list of all secrets that have one of the given IDs.
     async fn find_secrets<'a>(&self, secret_ids: &'a [&'a str]) -> Result<Vec<&'a str>>;
+
+    async fn create_signature(
+        &self,
+        secret_id: &str,
+        message: &[u8],
+        sig_type: Option<SignatureType>,
+    ) -> Result<SecretBytes>;
 
     async fn derive_aes_key_from_x25519_using_edch1pu(
         &self,
@@ -124,7 +136,9 @@ pub trait SecretsResolver {
     /// # Errors
     /// - IOError
     /// - InvalidState
-    async fn get_secret(&self, secret_id: &str) -> Result<Option<Secret>>;
+    // async fn get_secret(&self, secret_id: &str) -> Result<Option<Secret>>;
+
+    async fn get_key_alg(&self, secret_id: &str) -> Result<KeyAlg>;
 
     /// Find all secrets that have one of the given IDs.
     /// Return secrets only for key IDs for which a secret is present.
@@ -135,6 +149,13 @@ pub trait SecretsResolver {
     /// # Returns
     /// possible empty list of all secrets that have one of the given IDs.
     async fn find_secrets<'a>(&self, secret_ids: &'a [&'a str]) -> Result<Vec<&'a str>>;
+
+    async fn create_signature(
+        &self,
+        secret_id: &str,
+        message: &[u8],
+        sig_type: Option<SignatureType>,
+    ) -> Result<SecretBytes>;
 
     async fn derive_aes_key_from_x25519_using_edch1pu(
         &self,

--- a/src/secrets/resolvers/example.rs
+++ b/src/secrets/resolvers/example.rs
@@ -42,100 +42,100 @@ impl SecretsResolver for ExampleSecretsResolver {
 
     async fn derive_aes_key_from_x25519_using_edch1pu(
         &self,
-        ephem_key: &X25519KeyPair,
-        send_kid: &str,
-        recip_key: &X25519KeyPair,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
-        cc_tag: &[u8],
+        ephem_key: X25519KeyPair,
+        send_kid: String,
+        recip_key: X25519KeyPair,
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
+        cc_tag: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>> {
-        let key = self.get_secret(send_kid).await?.expect("Secret not found");
+        let key = self.get_secret(&send_kid).await?.expect("Secret not found");
 
         Ecdh1PU::derive_key(
-            ephem_key,
+            &ephem_key,
             Some(&key.as_x25519()?),
-            recip_key,
-            alg,
-            apu,
-            apv,
-            cc_tag,
+            &recip_key,
+            &alg,
+            &apu,
+            &apv,
+            &cc_tag,
             receive,
         )
     }
 
     async fn derive_aes_key_from_p256_using_edch1pu(
         &self,
-        ephem_key: &P256KeyPair,
-        send_kid: &str,
-        recip_key: &P256KeyPair,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
-        cc_tag: &[u8],
+        ephem_key: P256KeyPair,
+        send_kid: String,
+        recip_key: P256KeyPair,
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
+        cc_tag: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>> {
-        let key = self.get_secret(send_kid).await?.expect("Secret not found");
+        let key = self.get_secret(&send_kid).await?.expect("Secret not found");
 
         Ecdh1PU::derive_key(
-            ephem_key,
+            &ephem_key,
             Some(&key.as_p256()?),
-            recip_key,
-            alg,
-            apu,
-            apv,
-            cc_tag,
+            &recip_key,
+            &alg,
+            &apu,
+            &apv,
+            &cc_tag,
             receive,
         )
     }
 
     async fn derive_aes_key_from_x25519_using_edch1pu_receive(
         &self,
-        ephem_key: &X25519KeyPair,
-        send_key: &X25519KeyPair,
+        ephem_key: X25519KeyPair,
+        send_key: X25519KeyPair,
         recip_kid: &str,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
-        cc_tag: &[u8],
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
+        cc_tag: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>> {
         let key = self.get_secret(recip_kid).await?.expect("Secret not found");
 
         Ecdh1PU::derive_key(
-            ephem_key,
-            Some(send_key),
+            &ephem_key,
+            Some(&send_key),
             &key.as_x25519()?,
-            alg,
-            apu,
-            apv,
-            cc_tag,
+            &alg,
+            &apu,
+            &apv,
+            &cc_tag,
             receive,
         )
     }
 
     async fn derive_aes_key_from_p256_using_edch1pu_receive(
         &self,
-        ephem_key: &P256KeyPair,
-        send_key: &P256KeyPair,
+        ephem_key: P256KeyPair,
+        send_key: P256KeyPair,
         recip_kid: &str,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
-        cc_tag: &[u8],
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
+        cc_tag: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>> {
         let key = self.get_secret(recip_kid).await?.expect("Secret not found");
 
         Ecdh1PU::derive_key(
-            ephem_key,
-            Some(send_key),
+            &ephem_key,
+            Some(&send_key),
             &key.as_p256()?,
-            alg,
-            apu,
-            apv,
-            cc_tag,
+            &alg,
+            &apu,
+            &apv,
+            &cc_tag,
             receive,
         )
     }
@@ -144,9 +144,9 @@ impl SecretsResolver for ExampleSecretsResolver {
         &self,
         ephem_key: X25519KeyPair,
         recip_kid: &str,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>> {
         let key = self.get_secret(recip_kid).await?.expect("Secret not found");
@@ -155,9 +155,9 @@ impl SecretsResolver for ExampleSecretsResolver {
             &ephem_key,
             None,
             &key.as_x25519()?,
-            alg,
-            apu,
-            apv,
+            &alg,
+            &apu,
+            &apv,
             &[],
             receive,
         )
@@ -167,20 +167,20 @@ impl SecretsResolver for ExampleSecretsResolver {
         &self,
         ephem_key: P256KeyPair,
         recip_kid: &str,
-        alg: &[u8],
-        apu: &[u8],
-        apv: &[u8],
+        alg: Vec<u8>,
+        apu: Vec<u8>,
+        apv: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>> {
         let key = self.get_secret(recip_kid).await?.expect("Secret not found");
 
-        Ecdh1PU::derive_key(
+        EcdhEs::derive_key(
             &ephem_key,
             None,
             &key.as_p256()?,
-            alg,
-            apu,
-            apv,
+            &alg,
+            &apu,
+            &apv,
             &[],
             receive,
         )

--- a/src/secrets/resolvers/example.rs
+++ b/src/secrets/resolvers/example.rs
@@ -2,6 +2,7 @@ use askar_crypto::alg::aes::{A256Kw, AesKey};
 use askar_crypto::alg::p256::P256KeyPair;
 use askar_crypto::alg::x25519::X25519KeyPair;
 use askar_crypto::kdf::ecdh_1pu::Ecdh1PU;
+use askar_crypto::kdf::ecdh_es::EcdhEs;
 use async_trait::async_trait;
 
 use crate::utils::crypto::{AsKnownKeyPair, JoseKDF};
@@ -85,6 +86,102 @@ impl SecretsResolver for ExampleSecretsResolver {
             apu,
             apv,
             cc_tag,
+            receive,
+        )
+    }
+
+    async fn derive_aes_key_from_x25519_using_edch1pu_receive(
+        &self,
+        ephem_key: &X25519KeyPair,
+        send_key: &X25519KeyPair,
+        recip_kid: &str,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        cc_tag: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>> {
+        let key = self.get_secret(recip_kid).await?.expect("Secret not found");
+
+        Ecdh1PU::derive_key(
+            ephem_key,
+            Some(send_key),
+            &key.as_x25519()?,
+            alg,
+            apu,
+            apv,
+            cc_tag,
+            receive,
+        )
+    }
+
+    async fn derive_aes_key_from_p256_using_edch1pu_receive(
+        &self,
+        ephem_key: &P256KeyPair,
+        send_key: &P256KeyPair,
+        recip_kid: &str,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        cc_tag: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>> {
+        let key = self.get_secret(recip_kid).await?.expect("Secret not found");
+
+        Ecdh1PU::derive_key(
+            ephem_key,
+            Some(send_key),
+            &key.as_p256()?,
+            alg,
+            apu,
+            apv,
+            cc_tag,
+            receive,
+        )
+    }
+
+    async fn derive_aes_key_from_x25519_using_edches(
+        &self,
+        ephem_key: &X25519KeyPair,
+        recip_kid: &str,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>> {
+        let key = self.get_secret(recip_kid).await?.expect("Secret not found");
+
+        EcdhEs::derive_key(
+            ephem_key,
+            None,
+            &key.as_x25519()?,
+            alg,
+            apu,
+            apv,
+            &[],
+            receive,
+        )
+    }
+
+    async fn derive_aes_key_from_p256_using_edches(
+        &self,
+        ephem_key: &P256KeyPair,
+        recip_kid: &str,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>> {
+        let key = self.get_secret(recip_kid).await?.expect("Secret not found");
+
+        Ecdh1PU::derive_key(
+            ephem_key,
+            None,
+            &key.as_p256()?,
+            alg,
+            apu,
+            apv,
+            &[],
             receive,
         )
     }

--- a/src/secrets/resolvers/example.rs
+++ b/src/secrets/resolvers/example.rs
@@ -142,7 +142,7 @@ impl SecretsResolver for ExampleSecretsResolver {
 
     async fn derive_aes_key_from_x25519_using_edches(
         &self,
-        ephem_key: &X25519KeyPair,
+        ephem_key: X25519KeyPair,
         recip_kid: &str,
         alg: &[u8],
         apu: &[u8],
@@ -152,7 +152,7 @@ impl SecretsResolver for ExampleSecretsResolver {
         let key = self.get_secret(recip_kid).await?.expect("Secret not found");
 
         EcdhEs::derive_key(
-            ephem_key,
+            &ephem_key,
             None,
             &key.as_x25519()?,
             alg,
@@ -165,7 +165,7 @@ impl SecretsResolver for ExampleSecretsResolver {
 
     async fn derive_aes_key_from_p256_using_edches(
         &self,
-        ephem_key: &P256KeyPair,
+        ephem_key: P256KeyPair,
         recip_kid: &str,
         alg: &[u8],
         apu: &[u8],
@@ -175,7 +175,7 @@ impl SecretsResolver for ExampleSecretsResolver {
         let key = self.get_secret(recip_kid).await?.expect("Secret not found");
 
         Ecdh1PU::derive_key(
-            ephem_key,
+            &ephem_key,
             None,
             &key.as_p256()?,
             alg,

--- a/src/secrets/resolvers/example.rs
+++ b/src/secrets/resolvers/example.rs
@@ -1,41 +1,62 @@
-use crate::error::{err_msg, ErrorKind, ResultExt};
-use crate::secrets::{SecretMaterial, SecretType};
-use crate::utils::crypto::{AsKnownKeyPair, JoseKDF, KnownKeyPair};
-use crate::{
-    error::Result,
-    secrets::{Secret, SecretsResolver},
-};
+use crate::error::{err_msg, ErrorKind, ResultExt, ToResult};
+use crate::jwk::FromJwkValue;
+use crate::secrets::KeyOrKid;
+use crate::utils::crypto::{AsKnownKeyPair, JoseKDF, KnownKeyAlg, KnownKeyPair};
+use crate::utils::did::{Codec, _from_multicodec};
+use crate::{error::Result, secrets::KeyManagementService};
 use askar_crypto::alg::aes::{A256Kw, AesKey};
+use askar_crypto::alg::ed25519::Ed25519KeyPair;
+use askar_crypto::alg::k256::K256KeyPair;
 use askar_crypto::alg::p256::P256KeyPair;
 use askar_crypto::alg::x25519::X25519KeyPair;
 use askar_crypto::alg::{EcCurves, KeyAlg};
 use askar_crypto::buffer::SecretBytes;
 use askar_crypto::kdf::ecdh_1pu::Ecdh1PU;
 use askar_crypto::kdf::ecdh_es::EcdhEs;
+use askar_crypto::repr::{KeyPublicBytes, KeySecretBytes};
 use askar_crypto::sign::{KeySign, SignatureType};
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 
-pub struct ExampleSecretsResolver {
+pub struct ExampleKMS {
     known_secrets: Vec<Secret>,
 }
 
-impl ExampleSecretsResolver {
+impl ExampleKMS {
     pub fn new(known_secrets: Vec<Secret>) -> Self {
-        ExampleSecretsResolver { known_secrets }
+        ExampleKMS { known_secrets }
     }
 
-    async fn get_secret(&self, secret_id: &str) -> Result<Option<Secret>> {
-        Ok(self
-            .known_secrets
+    fn get_secret(&self, secret_id: &str) -> Result<Secret> {
+        self.known_secrets
             .iter()
             .find(|s| s.id == secret_id)
-            .map(|s| s.clone()))
+            .map(|s| s.clone())
+            .ok_or(err_msg(ErrorKind::InvalidState, "Secret not found"))
+    }
+
+    fn resolve_kid(&self, x: KeyOrKid) -> Result<KeyOrKid> {
+        match x {
+            KeyOrKid::Kid(kid) => {
+                let secret = self.get_secret(&kid)?;
+                match secret.as_key_pair()? {
+                    KnownKeyPair::X25519(key) => Ok(KeyOrKid::X25519KeyPair(key)),
+                    KnownKeyPair::P256(key) => Ok(KeyOrKid::P256KeyPair(key)),
+                    _ => Err(err_msg(
+                        ErrorKind::Unsupported,
+                        "Unsupported key type found",
+                    )),
+                }
+            }
+            key => Ok(key),
+        }
     }
 }
 
 #[cfg_attr(feature = "uniffi", async_trait)]
 #[cfg_attr(not(feature = "uniffi"), async_trait(?Send))]
-impl SecretsResolver for ExampleSecretsResolver {
+impl KeyManagementService for ExampleKMS {
     async fn get_key_alg(&self, secret_id: &str) -> Result<KeyAlg> {
         let secret = self
             .known_secrets
@@ -116,7 +137,7 @@ impl SecretsResolver for ExampleSecretsResolver {
             .cloned()
             .expect("Secret not found");
         match secret.as_key_pair()? {
-            KnownKeyPair::X25519(ref key) => {
+            KnownKeyPair::X25519(_) => {
                 Err(err_msg(ErrorKind::Unsupported, "Unsupported signature alg"))
             }
             KnownKeyPair::Ed25519(key) => key
@@ -131,149 +152,353 @@ impl SecretsResolver for ExampleSecretsResolver {
         }
     }
 
-    async fn derive_aes_key_from_x25519_using_edch1pu(
+    async fn derive_aes_key_using_ecdh_1pu(
         &self,
-        ephem_key: X25519KeyPair,
-        send_kid: String,
-        recip_key: X25519KeyPair,
+        ephem_key: KeyOrKid,
+        send_key: KeyOrKid,
+        recip_key: KeyOrKid,
         alg: Vec<u8>,
         apu: Vec<u8>,
         apv: Vec<u8>,
         cc_tag: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>> {
-        let key = self.get_secret(&send_kid).await?.expect("Secret not found");
+        // resolve possible key ids to keys
+        let send_key = self.resolve_kid(send_key)?;
+        let recip_key = self.resolve_kid(recip_key)?;
 
-        Ecdh1PU::derive_key(
-            &ephem_key,
-            Some(&key.as_x25519()?),
-            &recip_key,
-            &alg,
-            &apu,
-            &apv,
-            &cc_tag,
-            receive,
-        )
+        match (ephem_key, send_key, recip_key) {
+            (
+                KeyOrKid::X25519KeyPair(ephem_key),
+                KeyOrKid::X25519KeyPair(send_key),
+                KeyOrKid::X25519KeyPair(recip_key),
+            ) => Ecdh1PU::derive_key(
+                &ephem_key,
+                Some(&send_key),
+                &recip_key,
+                &alg,
+                &apu,
+                &apv,
+                &cc_tag,
+                receive,
+            ),
+            (
+                KeyOrKid::P256KeyPair(ephem_key),
+                KeyOrKid::P256KeyPair(send_key),
+                KeyOrKid::P256KeyPair(recip_key),
+            ) => Ecdh1PU::derive_key(
+                &ephem_key,
+                Some(&send_key),
+                &recip_key,
+                &alg,
+                &apu,
+                &apv,
+                &cc_tag,
+                receive,
+            ),
+            _ => Err(err_msg(ErrorKind::Unsupported, "Unsupported derive keys")),
+        }
     }
 
-    async fn derive_aes_key_from_p256_using_edch1pu(
+    async fn derive_aes_key_using_ecdh_es(
         &self,
-        ephem_key: P256KeyPair,
-        send_kid: String,
-        recip_key: P256KeyPair,
-        alg: Vec<u8>,
-        apu: Vec<u8>,
-        apv: Vec<u8>,
-        cc_tag: Vec<u8>,
-        receive: bool,
-    ) -> Result<AesKey<A256Kw>> {
-        let key = self.get_secret(&send_kid).await?.expect("Secret not found");
-
-        Ecdh1PU::derive_key(
-            &ephem_key,
-            Some(&key.as_p256()?),
-            &recip_key,
-            &alg,
-            &apu,
-            &apv,
-            &cc_tag,
-            receive,
-        )
-    }
-
-    async fn derive_aes_key_from_x25519_using_edch1pu_receive(
-        &self,
-        ephem_key: X25519KeyPair,
-        send_key: X25519KeyPair,
-        recip_kid: &str,
-        alg: Vec<u8>,
-        apu: Vec<u8>,
-        apv: Vec<u8>,
-        cc_tag: Vec<u8>,
-        receive: bool,
-    ) -> Result<AesKey<A256Kw>> {
-        let key = self.get_secret(recip_kid).await?.expect("Secret not found");
-
-        Ecdh1PU::derive_key(
-            &ephem_key,
-            Some(&send_key),
-            &key.as_x25519()?,
-            &alg,
-            &apu,
-            &apv,
-            &cc_tag,
-            receive,
-        )
-    }
-
-    async fn derive_aes_key_from_p256_using_edch1pu_receive(
-        &self,
-        ephem_key: P256KeyPair,
-        send_key: P256KeyPair,
-        recip_kid: &str,
-        alg: Vec<u8>,
-        apu: Vec<u8>,
-        apv: Vec<u8>,
-        cc_tag: Vec<u8>,
-        receive: bool,
-    ) -> Result<AesKey<A256Kw>> {
-        let key = self.get_secret(recip_kid).await?.expect("Secret not found");
-
-        Ecdh1PU::derive_key(
-            &ephem_key,
-            Some(&send_key),
-            &key.as_p256()?,
-            &alg,
-            &apu,
-            &apv,
-            &cc_tag,
-            receive,
-        )
-    }
-
-    async fn derive_aes_key_from_x25519_using_edches(
-        &self,
-        ephem_key: X25519KeyPair,
-        recip_kid: &str,
+        ephem_key: KeyOrKid,
+        recip_key: KeyOrKid,
         alg: Vec<u8>,
         apu: Vec<u8>,
         apv: Vec<u8>,
         receive: bool,
     ) -> Result<AesKey<A256Kw>> {
-        let key = self.get_secret(recip_kid).await?.expect("Secret not found");
+        // resolve possible key ids to keys
+        let recip_key = self.resolve_kid(recip_key)?;
 
-        EcdhEs::derive_key(
-            &ephem_key,
-            None,
-            &key.as_x25519()?,
-            &alg,
-            &apu,
-            &apv,
-            &[],
-            receive,
-        )
+        match (ephem_key, recip_key) {
+            (KeyOrKid::X25519KeyPair(ephem_key), KeyOrKid::X25519KeyPair(recip_key)) => {
+                EcdhEs::derive_key(&ephem_key, None, &recip_key, &alg, &apu, &apv, &[], receive)
+            }
+            (KeyOrKid::P256KeyPair(ephem_key), KeyOrKid::P256KeyPair(recip_key)) => {
+                EcdhEs::derive_key(&ephem_key, None, &recip_key, &alg, &apu, &apv, &[], receive)
+            }
+            _ => Err(err_msg(ErrorKind::Unsupported, "Unsupported derive keys")),
+        }
+    }
+}
+
+/// Represents secret.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Secret {
+    /// A key ID identifying a secret (private key).
+    pub id: String,
+
+    /// Must have the same semantics as type ('type' field) of the corresponding method in DID Doc containing a public key.
+    #[serde(rename = "type")]
+    pub type_: SecretType,
+
+    /// Value of the secret (private key)
+    #[serde(flatten)]
+    pub secret_material: SecretMaterial,
+}
+
+/// Must have the same semantics as type ('type' field) of the corresponding method in DID Doc containing a public key.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum SecretType {
+    JsonWebKey2020,
+    X25519KeyAgreementKey2019,
+    X25519KeyAgreementKey2020,
+    Ed25519VerificationKey2018,
+    Ed25519VerificationKey2020,
+    EcdsaSecp256k1VerificationKey2019,
+    Other,
+}
+
+/// Represents secret crypto material.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum SecretMaterial {
+    #[serde(rename_all = "camelCase")]
+    JWK { private_key_jwk: Value },
+
+    #[serde(rename_all = "camelCase")]
+    Multibase { private_key_multibase: String },
+
+    #[serde(rename_all = "camelCase")]
+    Base58 { private_key_base58: String },
+}
+
+impl AsKnownKeyPair for Secret {
+    fn key_alg(&self) -> KnownKeyAlg {
+        match (&self.type_, &self.secret_material) {
+            (
+                SecretType::JsonWebKey2020,
+                SecretMaterial::JWK {
+                    private_key_jwk: ref value,
+                },
+            ) => match (value["kty"].as_str(), value["crv"].as_str()) {
+                (Some(kty), Some(crv)) if kty == "EC" && crv == "P-256" => KnownKeyAlg::P256,
+                (Some(kty), Some(crv)) if kty == "EC" && crv == "secp256k1" => KnownKeyAlg::K256,
+                (Some(kty), Some(crv)) if kty == "OKP" && crv == "Ed25519" => KnownKeyAlg::Ed25519,
+                (Some(kty), Some(crv)) if kty == "OKP" && crv == "X25519" => KnownKeyAlg::X25519,
+                _ => KnownKeyAlg::Unsupported,
+            },
+            (
+                SecretType::X25519KeyAgreementKey2019,
+                SecretMaterial::Base58 {
+                    private_key_base58: _,
+                },
+            ) => KnownKeyAlg::X25519,
+            (
+                SecretType::Ed25519VerificationKey2018,
+                SecretMaterial::Base58 {
+                    private_key_base58: _,
+                },
+            ) => KnownKeyAlg::Ed25519,
+            (
+                SecretType::X25519KeyAgreementKey2020,
+                SecretMaterial::Multibase {
+                    private_key_multibase: _,
+                },
+            ) => KnownKeyAlg::X25519,
+            (
+                SecretType::Ed25519VerificationKey2020,
+                SecretMaterial::Multibase {
+                    private_key_multibase: _,
+                },
+            ) => KnownKeyAlg::Ed25519,
+            _ => KnownKeyAlg::Unsupported,
+        }
     }
 
-    async fn derive_aes_key_from_p256_using_edches(
-        &self,
-        ephem_key: P256KeyPair,
-        recip_kid: &str,
-        alg: Vec<u8>,
-        apu: Vec<u8>,
-        apv: Vec<u8>,
-        receive: bool,
-    ) -> Result<AesKey<A256Kw>> {
-        let key = self.get_secret(recip_kid).await?.expect("Secret not found");
+    fn as_key_pair(&self) -> Result<KnownKeyPair> {
+        match (&self.type_, &self.secret_material) {
+            (
+                SecretType::JsonWebKey2020,
+                SecretMaterial::JWK {
+                    private_key_jwk: ref value,
+                },
+            ) => match (value["kty"].as_str(), value["crv"].as_str()) {
+                (Some(kty), Some(crv)) if kty == "EC" && crv == "P-256" => {
+                    P256KeyPair::from_jwk_value(value)
+                        .kind(ErrorKind::Malformed, "Unable parse jwk")
+                        .map(KnownKeyPair::P256)
+                }
+                (Some(kty), Some(crv)) if kty == "EC" && crv == "secp256k1" => {
+                    K256KeyPair::from_jwk_value(value)
+                        .kind(ErrorKind::Malformed, "Unable parse jwk")
+                        .map(KnownKeyPair::K256)
+                }
+                (Some(kty), Some(crv)) if kty == "OKP" && crv == "Ed25519" => {
+                    Ed25519KeyPair::from_jwk_value(value)
+                        .kind(ErrorKind::Malformed, "Unable parse jwk")
+                        .map(KnownKeyPair::Ed25519)
+                }
+                (Some(kty), Some(crv)) if kty == "OKP" && crv == "X25519" => {
+                    X25519KeyPair::from_jwk_value(value)
+                        .kind(ErrorKind::Malformed, "Unable parse jwk")
+                        .map(KnownKeyPair::X25519)
+                }
+                _ => Err(err_msg(
+                    ErrorKind::Unsupported,
+                    "Unsupported key type or curve",
+                )),
+            },
 
-        EcdhEs::derive_key(
-            &ephem_key,
-            None,
-            &key.as_p256()?,
-            &alg,
-            &apu,
-            &apv,
-            &[],
-            receive,
-        )
+            (
+                SecretType::X25519KeyAgreementKey2019,
+                SecretMaterial::Base58 {
+                    private_key_base58: ref value,
+                },
+            ) => {
+                let decoded_value = bs58::decode(value)
+                    .into_vec()
+                    .to_didcomm("Wrong base58 value in secret material")?;
+
+                let key_pair = X25519KeyPair::from_secret_bytes(&decoded_value)
+                    .kind(ErrorKind::Malformed, "Unable parse x25519 secret material")?;
+
+                let mut jwk = json!({
+                    "kty": "OKP",
+                    "crv": "X25519",
+                });
+
+                key_pair.with_public_bytes(|buf| {
+                    jwk["x"] = Value::String(base64::encode_config(buf, base64::URL_SAFE_NO_PAD))
+                });
+
+                key_pair.with_secret_bytes(|buf| {
+                    if let Some(sk) = buf {
+                        jwk["d"] = Value::String(base64::encode_config(sk, base64::URL_SAFE_NO_PAD))
+                    }
+                });
+
+                X25519KeyPair::from_jwk_value(&jwk)
+                    .kind(ErrorKind::Malformed, "Unable parse base58 secret material")
+                    .map(KnownKeyPair::X25519)
+            }
+
+            (
+                SecretType::Ed25519VerificationKey2018,
+                SecretMaterial::Base58 {
+                    private_key_base58: ref value,
+                },
+            ) => {
+                let decoded_value = bs58::decode(value)
+                    .into_vec()
+                    .to_didcomm("Wrong base58 value in secret material")?;
+
+                let curve25519_point_size = 32;
+                let (d_value, x_value) = decoded_value.split_at(curve25519_point_size);
+                let base64_url_d_value = base64::encode_config(&d_value, base64::URL_SAFE_NO_PAD);
+                let base64_url_x_value = base64::encode_config(&x_value, base64::URL_SAFE_NO_PAD);
+
+                let jwk = json!({"kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": base64_url_x_value,
+                    "d": base64_url_d_value
+                });
+
+                Ed25519KeyPair::from_jwk_value(&jwk)
+                    .kind(ErrorKind::Malformed, "Unable parse base58 secret material")
+                    .map(KnownKeyPair::Ed25519)
+            }
+
+            (
+                SecretType::X25519KeyAgreementKey2020,
+                SecretMaterial::Multibase {
+                    private_key_multibase: ref value,
+                },
+            ) => {
+                if !value.starts_with('z') {
+                    Err(err_msg(
+                        ErrorKind::IllegalArgument,
+                        "Multibase must start with 'z'",
+                    ))?
+                }
+                let decoded_multibase_value = bs58::decode(&value[1..])
+                    .into_vec()
+                    .to_didcomm("Wrong multibase value in secret material")?;
+
+                let (codec, decoded_value) = _from_multicodec(&decoded_multibase_value)?;
+                if codec != Codec::X25519Priv {
+                    Err(err_msg(
+                        ErrorKind::IllegalArgument,
+                        "Wrong codec in multibase secret material",
+                    ))?
+                }
+
+                let key_pair = X25519KeyPair::from_secret_bytes(&decoded_value)
+                    .kind(ErrorKind::Malformed, "Unable parse x25519 secret material")?;
+
+                let mut jwk = json!({
+                    "kty": "OKP",
+                    "crv": "X25519",
+                });
+
+                key_pair.with_public_bytes(|buf| {
+                    jwk["x"] = Value::String(base64::encode_config(buf, base64::URL_SAFE_NO_PAD))
+                });
+
+                key_pair.with_secret_bytes(|buf| {
+                    if let Some(sk) = buf {
+                        jwk["d"] = Value::String(base64::encode_config(sk, base64::URL_SAFE_NO_PAD))
+                    }
+                });
+
+                X25519KeyPair::from_jwk_value(&jwk)
+                    .kind(
+                        ErrorKind::Malformed,
+                        "Unable parse multibase secret material",
+                    )
+                    .map(KnownKeyPair::X25519)
+            }
+
+            (
+                SecretType::Ed25519VerificationKey2020,
+                SecretMaterial::Multibase {
+                    private_key_multibase: ref value,
+                },
+            ) => {
+                if !value.starts_with('z') {
+                    Err(err_msg(
+                        ErrorKind::IllegalArgument,
+                        "Multibase must start with 'z'",
+                    ))?
+                }
+                let decoded_multibase_value = bs58::decode(&value[1..])
+                    .into_vec()
+                    .to_didcomm("Wrong multibase value in secret material")?;
+
+                let (codec, decoded_value) = _from_multicodec(&decoded_multibase_value)?;
+                if codec != Codec::Ed25519Priv {
+                    Err(err_msg(
+                        ErrorKind::IllegalArgument,
+                        "Wrong codec in multibase secret material",
+                    ))?
+                }
+
+                let curve25519_point_size = 32;
+                let (d_value, x_value) = decoded_value.split_at(curve25519_point_size);
+                let base64_url_d_value = base64::encode_config(&d_value, base64::URL_SAFE_NO_PAD);
+                let base64_url_x_value = base64::encode_config(&x_value, base64::URL_SAFE_NO_PAD);
+
+                let jwk = json!({
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": base64_url_x_value,
+                    "d": base64_url_d_value
+                });
+
+                Ed25519KeyPair::from_jwk_value(&jwk)
+                    .kind(
+                        ErrorKind::Malformed,
+                        "Unable parse multibase secret material",
+                    )
+                    .map(KnownKeyPair::Ed25519)
+            }
+
+            _ => Err(err_msg(
+                ErrorKind::Unsupported,
+                "Unsupported secret method type and material combination",
+            )),
+        }
     }
 }

--- a/src/secrets/resolvers/example.rs
+++ b/src/secrets/resolvers/example.rs
@@ -1,5 +1,10 @@
+use askar_crypto::alg::aes::{A256Kw, AesKey};
+use askar_crypto::alg::p256::P256KeyPair;
+use askar_crypto::alg::x25519::X25519KeyPair;
+use askar_crypto::kdf::ecdh_1pu::Ecdh1PU;
 use async_trait::async_trait;
 
+use crate::utils::crypto::{AsKnownKeyPair, JoseKDF};
 use crate::{
     error::Result,
     secrets::{Secret, SecretsResolver},
@@ -32,5 +37,55 @@ impl SecretsResolver for ExampleSecretsResolver {
             .filter(|&&sid| self.known_secrets.iter().find(|s| s.id == sid).is_some())
             .map(|sid| *sid)
             .collect())
+    }
+
+    async fn derive_aes_key_from_x25519_using_edch1pu(
+        &self,
+        ephem_key: &X25519KeyPair,
+        send_kid: &str,
+        recip_key: &X25519KeyPair,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        cc_tag: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>> {
+        let key = self.get_secret(send_kid).await?.expect("Secret not found");
+
+        Ecdh1PU::derive_key(
+            ephem_key,
+            Some(&key.as_x25519()?),
+            recip_key,
+            alg,
+            apu,
+            apv,
+            cc_tag,
+            receive,
+        )
+    }
+
+    async fn derive_aes_key_from_p256_using_edch1pu(
+        &self,
+        ephem_key: &P256KeyPair,
+        send_kid: &str,
+        recip_key: &P256KeyPair,
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        cc_tag: &[u8],
+        receive: bool,
+    ) -> Result<AesKey<A256Kw>> {
+        let key = self.get_secret(send_kid).await?.expect("Secret not found");
+
+        Ecdh1PU::derive_key(
+            ephem_key,
+            Some(&key.as_p256()?),
+            recip_key,
+            alg,
+            apu,
+            apv,
+            cc_tag,
+            receive,
+        )
     }
 }

--- a/src/secrets/resolvers/example.rs
+++ b/src/secrets/resolvers/example.rs
@@ -1,15 +1,19 @@
-use askar_crypto::alg::aes::{A256Kw, AesKey};
-use askar_crypto::alg::p256::P256KeyPair;
-use askar_crypto::alg::x25519::X25519KeyPair;
-use askar_crypto::kdf::ecdh_1pu::Ecdh1PU;
-use askar_crypto::kdf::ecdh_es::EcdhEs;
-use async_trait::async_trait;
-
-use crate::utils::crypto::{AsKnownKeyPair, JoseKDF};
+use crate::error::{err_msg, ErrorKind, ResultExt};
+use crate::secrets::{SecretMaterial, SecretType};
+use crate::utils::crypto::{AsKnownKeyPair, JoseKDF, KnownKeyPair};
 use crate::{
     error::Result,
     secrets::{Secret, SecretsResolver},
 };
+use askar_crypto::alg::aes::{A256Kw, AesKey};
+use askar_crypto::alg::p256::P256KeyPair;
+use askar_crypto::alg::x25519::X25519KeyPair;
+use askar_crypto::alg::{EcCurves, KeyAlg};
+use askar_crypto::buffer::SecretBytes;
+use askar_crypto::kdf::ecdh_1pu::Ecdh1PU;
+use askar_crypto::kdf::ecdh_es::EcdhEs;
+use askar_crypto::sign::{KeySign, SignatureType};
+use async_trait::async_trait;
 
 pub struct ExampleSecretsResolver {
     known_secrets: Vec<Secret>,
@@ -19,17 +23,76 @@ impl ExampleSecretsResolver {
     pub fn new(known_secrets: Vec<Secret>) -> Self {
         ExampleSecretsResolver { known_secrets }
     }
-}
 
-#[cfg_attr(feature = "uniffi", async_trait)]
-#[cfg_attr(not(feature = "uniffi"), async_trait(?Send))]
-impl SecretsResolver for ExampleSecretsResolver {
     async fn get_secret(&self, secret_id: &str) -> Result<Option<Secret>> {
         Ok(self
             .known_secrets
             .iter()
             .find(|s| s.id == secret_id)
             .map(|s| s.clone()))
+    }
+}
+
+#[cfg_attr(feature = "uniffi", async_trait)]
+#[cfg_attr(not(feature = "uniffi"), async_trait(?Send))]
+impl SecretsResolver for ExampleSecretsResolver {
+    async fn get_key_alg(&self, secret_id: &str) -> Result<KeyAlg> {
+        let secret = self
+            .known_secrets
+            .iter()
+            .find(|s| s.id == secret_id)
+            .cloned()
+            .ok_or(err_msg(ErrorKind::InvalidState, "Secret not found"))?;
+
+        match (&secret.type_, &secret.secret_material) {
+            (
+                SecretType::JsonWebKey2020,
+                SecretMaterial::JWK {
+                    private_key_jwk: ref value,
+                },
+            ) => match (value["kty"].as_str(), value["crv"].as_str()) {
+                (Some(kty), Some(crv)) if kty == "EC" && crv == "P-256" => {
+                    Ok(KeyAlg::EcCurve(EcCurves::Secp256r1))
+                }
+                (Some(kty), Some(crv)) if kty == "EC" && crv == "secp256k1" => {
+                    Ok(KeyAlg::EcCurve(EcCurves::Secp256k1))
+                }
+                (Some(kty), Some(crv)) if kty == "OKP" && crv == "Ed25519" => Ok(KeyAlg::Ed25519),
+                (Some(kty), Some(crv)) if kty == "OKP" && crv == "X25519" => Ok(KeyAlg::X25519),
+                _ => Err(err_msg(
+                    ErrorKind::Unsupported,
+                    "Unsupported key type or curve",
+                )),
+            },
+            (
+                SecretType::X25519KeyAgreementKey2019,
+                SecretMaterial::Base58 {
+                    private_key_base58: _,
+                },
+            ) => Ok(KeyAlg::X25519),
+            (
+                SecretType::Ed25519VerificationKey2018,
+                SecretMaterial::Base58 {
+                    private_key_base58: _,
+                },
+            ) => Ok(KeyAlg::Ed25519),
+            (
+                SecretType::X25519KeyAgreementKey2020,
+                SecretMaterial::Multibase {
+                    private_key_multibase: _,
+                },
+            ) => Ok(KeyAlg::X25519),
+            (
+                SecretType::Ed25519VerificationKey2020,
+                SecretMaterial::Multibase {
+                    private_key_multibase: _,
+                },
+            ) => Ok(KeyAlg::Ed25519),
+            _ => Err(err_msg(
+                ErrorKind::Unsupported,
+                "Unsupported key type or curve",
+            )),
+        }
     }
 
     async fn find_secrets<'a>(&self, secret_ids: &'a [&'a str]) -> Result<Vec<&'a str>> {
@@ -38,6 +101,34 @@ impl SecretsResolver for ExampleSecretsResolver {
             .filter(|&&sid| self.known_secrets.iter().find(|s| s.id == sid).is_some())
             .map(|sid| *sid)
             .collect())
+    }
+
+    async fn create_signature(
+        &self,
+        secret_id: &str,
+        message: &[u8],
+        sig_type: Option<SignatureType>,
+    ) -> Result<SecretBytes> {
+        let secret = self
+            .known_secrets
+            .iter()
+            .find(|s| s.id == secret_id)
+            .cloned()
+            .expect("Secret not found");
+        match secret.as_key_pair()? {
+            KnownKeyPair::X25519(ref key) => {
+                Err(err_msg(ErrorKind::Unsupported, "Unsupported signature alg"))
+            }
+            KnownKeyPair::Ed25519(key) => key
+                .create_signature(message, sig_type)
+                .kind(ErrorKind::InvalidState, "Unable create signature"),
+            KnownKeyPair::P256(key) => key
+                .create_signature(message, sig_type)
+                .kind(ErrorKind::InvalidState, "Unable create signature"),
+            KnownKeyPair::K256(key) => key
+                .create_signature(message, sig_type)
+                .kind(ErrorKind::InvalidState, "Unable create signature"),
+        }
     }
 
     async fn derive_aes_key_from_x25519_using_edch1pu(

--- a/src/secrets/resolvers/mod.rs
+++ b/src/secrets/resolvers/mod.rs
@@ -1,3 +1,3 @@
-mod example;
+pub mod example;
 
-pub use example::ExampleSecretsResolver;
+pub use example::ExampleKMS;

--- a/src/test_vectors/secrets/alice.rs
+++ b/src/test_vectors/secrets/alice.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use serde_json::json;
 
-use crate::didcomm::secrets::{Secret, SecretMaterial, SecretType};
+use crate::didcomm::secrets::resolvers::example::{Secret, SecretMaterial, SecretType};
 
 lazy_static! {
     pub static ref ALICE_SECRET_AUTH_KEY_ED25519: Secret = Secret {

--- a/src/test_vectors/secrets/bob.rs
+++ b/src/test_vectors/secrets/bob.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use serde_json::json;
 
-use crate::didcomm::secrets::{Secret, SecretMaterial, SecretType};
+use crate::didcomm::secrets::resolvers::example::{Secret, SecretMaterial, SecretType};
 
 lazy_static! {
     pub static ref BOB_SECRET_KEY_AGREEMENT_KEY_X25519_1: Secret = Secret {

--- a/src/test_vectors/secrets/charlie.rs
+++ b/src/test_vectors/secrets/charlie.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use serde_json::json;
 
-use crate::didcomm::secrets::{Secret, SecretMaterial, SecretType};
+use crate::didcomm::secrets::resolvers::example::{Secret, SecretMaterial, SecretType};
 
 lazy_static! {
     pub static ref CHARLIE_SECRET_KEY_AGREEMENT_KEY_X25519: Secret = Secret {

--- a/src/test_vectors/secrets/charlie_rotated_to_alice.rs
+++ b/src/test_vectors/secrets/charlie_rotated_to_alice.rs
@@ -1,6 +1,6 @@
 use lazy_static::lazy_static;
 
-use crate::didcomm::secrets::Secret;
+use crate::didcomm::secrets::resolvers::example::Secret;
 
 use super::{
     alice::{

--- a/src/test_vectors/secrets/mediator1.rs
+++ b/src/test_vectors/secrets/mediator1.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use serde_json::json;
 
-use crate::didcomm::secrets::{Secret, SecretMaterial, SecretType};
+use crate::didcomm::secrets::resolvers::example::{Secret, SecretMaterial, SecretType};
 
 lazy_static! {
     pub static ref MEDIATOR1_SECRET_KEY_AGREEMENT_KEY_X25519_1: Secret = Secret {

--- a/src/test_vectors/secrets/mediator2.rs
+++ b/src/test_vectors/secrets/mediator2.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use serde_json::json;
 
-use crate::didcomm::secrets::{Secret, SecretMaterial, SecretType};
+use crate::didcomm::secrets::resolvers::example::{Secret, SecretMaterial, SecretType};
 
 lazy_static! {
     pub static ref MEDIATOR2_SECRET_KEY_AGREEMENT_KEY_X25519_1: Secret = Secret {

--- a/src/test_vectors/secrets/mediator3.rs
+++ b/src/test_vectors/secrets/mediator3.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use serde_json::json;
 
-use crate::didcomm::secrets::{Secret, SecretMaterial, SecretType};
+use crate::didcomm::secrets::resolvers::example::{Secret, SecretMaterial, SecretType};
 
 lazy_static! {
     pub static ref MEDIATOR3_SECRET_KEY_AGREEMENT_KEY_X25519_1: Secret = Secret {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,14 +6,17 @@ pub(crate) mod crypto;
 pub(crate) mod did;
 pub(crate) mod serde;
 
+/// Sized feature needed just for compiler to deduce Sized type
+/// Do NOT use as a real feature.
 pub struct DummyFuture<OUT> {
+    #[allow(dead_code)]
     value: OUT,
 }
 
 impl<OUT> Future for DummyFuture<OUT> {
     type Output = OUT;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
         Poll::Pending
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,19 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
 pub(crate) mod crypto;
 pub(crate) mod did;
 pub(crate) mod serde;
+
+pub struct DummyFuture<OUT> {
+    value: OUT,
+}
+
+impl<OUT> Future for DummyFuture<OUT> {
+    type Output = OUT;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Pending
+    }
+}


### PR DESCRIPTION
The idea is to refactor SecretsResolver which provided the private key to the library, so that it does not need to hand it down. KMS will do the operations with the private key by itself.